### PR TITLE
feat(irrigation): competition setup, benchmark & experiment runner

### DIFF
--- a/Predicting Irrigation Need/.gitignore
+++ b/Predicting Irrigation Need/.gitignore
@@ -1,0 +1,15 @@
+results.tsv
+history/*
+!history/README.md
+logs/*
+!logs/README.md
+submissions/*
+!submissions/README.md
+artifacts/data_profile.md
+artifacts/benchmark_summary.md
+artifacts/progress.png
+artifacts/approach_memory.md
+artifacts/experiment_runs/*
+!artifacts/experiment_runs/README.md
+src/__pycache__/
+.ipynb_checkpoints/

--- a/Predicting Irrigation Need/DIARY.md
+++ b/Predicting Irrigation Need/DIARY.md
@@ -1,0 +1,11 @@
+# Diary
+
+Use this file for short dated research notes.
+
+Suggested format:
+
+## YYYY-MM-DD
+
+- What changed and why.
+- Result: did the benchmark improve?
+- Follow-up idea or open question.

--- a/Predicting Irrigation Need/DOCKER.md
+++ b/Predicting Irrigation Need/DOCKER.md
@@ -1,0 +1,42 @@
+# Optional Container Isolation
+
+This competition includes an optional Docker runner for stronger guardrails during longer autonomous runs.
+
+The container protects the fixed parts of the workspace:
+
+- `data/` is mounted read-only.
+- `README.md` is mounted read-only.
+- `AGENTS.md` is mounted read-only.
+- `program.md` is mounted read-only.
+- `src/profile_data.py` is mounted read-only.
+- `src/benchmark.py` is mounted read-only.
+- `src/evaluate.py` is mounted read-only.
+- `benchmark/holdout_v1/` is mounted read-only.
+
+The writable surfaces stay available to the agent:
+
+- `src/experiment.py`
+- `artifacts/`
+- `logs/`
+- `submissions/`
+- `history/`
+- `results.tsv`
+- `DIARY.md`
+
+## Start The Container
+
+From the competition folder:
+
+```bash
+bash run_agent_container.sh
+```
+
+This starts an interactive shell after running `uv sync --frozen`.
+
+Inside the container, the environment lives at `./.venv` via `UV_PROJECT_ENVIRONMENT=/workspace/competition/.venv`, so the shared repo root can remain read-only.
+
+## Notes
+
+- This is an optional safety layer, not a replacement for the fixed benchmark harness.
+- The current container setup protects files, not network access.
+- The benchmark block in `README.md` can still be refreshed outside the container by running `uv run python src/analyze_results.py` locally.

--- a/Predicting Irrigation Need/README.md
+++ b/Predicting Irrigation Need/README.md
@@ -1,4 +1,16 @@
-Predicting Irrigation Need
+# Predicting Irrigation Need
+
+## Current Benchmark
+
+This section should stay short and factual. `src/analyze_results.py` can refresh it from `results.tsv` when `README.md` is writable.
+
+<!-- benchmark:start -->
+- Metric: `balanced_accuracy` (`maximize`)
+- Total logged runs: `15`
+- Best full: not run yet
+- Best smoke: `0.969515` via `catboost_v12` (`ran`; run `20260428-000410-dirty`)
+- Last updated: 2026-04-27 22:21 UTC
+<!-- benchmark:end -->
 
 Playground Series - Season 6 Episode 4
 Predicting Irrigation Need
@@ -60,4 +72,3 @@ Files
     train.csv - the training set, with Irrigation_Need as target
     test.csv - the test set, used to predict the category for Irrigation_Need
     sample_submission.csv - a sample submission file in the correct format
-

--- a/Predicting Irrigation Need/README.md
+++ b/Predicting Irrigation Need/README.md
@@ -1,0 +1,63 @@
+Predicting Irrigation Need
+
+Playground Series - Season 6 Episode 4
+Predicting Irrigation Need
+Overview
+
+Welcome to the 2026 Kaggle Playground Series! We plan to continue in the spirit of previous playgrounds, providing interesting and approachable datasets for our community to practice their machine learning skills, and anticipate a competition each month.
+
+Your Goal: Predict the irrigation need.
+
+Start
+12 days ago
+
+Close
+18 days to go
+Evaluation
+
+Submissions are evaluated on balanced accuracy between the predicted class and observed target.
+Submission File
+
+For each id in the test set, you must predict a class label (Low, Medium, High) for the Irrigation_Need target. The file should contain a header and have the following format:
+
+id,Irrigation_Need
+630000,Low
+630001,High
+630002,Low
+etc.
+
+Timeline
+
+    Start Date - April 1, 2026
+    Entry Deadline - Same as the Final Submission Deadline
+    Team Merger Deadline - Same as the Final Submission Deadline
+    Final Submission Deadline - April 30, 2026
+
+All deadlines are at 11:59 PM UTC on the corresponding day unless otherwise noted. The competition organizers reserve the right to update the contest timeline if they deem it necessary.
+About the Tabular Playground Series
+
+The goal of the Tabular Playground Series is to provide the Kaggle community with a variety of fairly light-weight challenges that can be used to learn and sharpen skills in different aspects of machine learning and data science. The duration of each competition will generally only last a few weeks, and may have longer or shorter durations depending on the challenge. The challenges will generally use fairly light-weight datasets that are synthetically generated from real-world data, and will provide an opportunity to quickly iterate through various model and feature engineering ideas, create visualizations, etc.
+Synthetically-Generated Datasets
+
+Using synthetic data for Playground competitions allows us to strike a balance between having real-world data (with named features) and ensuring test labels are not publicly available. This allows us to host competitions with more interesting datasets than in the past. While there are still challenges with synthetic data generation, the state-of-the-art is much better now than when we started the Tabular Playground Series two years ago, and that goal is to produce datasets that have far fewer artifacts. Please feel free to give us feedback on the datasets for the different competitions so that we can continue to improve!
+Prizes
+
+    1st Place - Choice of Kaggle merchandise
+    2nd Place - Choice of Kaggle merchandise
+    3rd Place - Choice of Kaggle merchandise
+
+Please note: In order to encourage more participation from beginners, Kaggle merchandise will only be awarded once per person in this series. If a person has previously won, we'll skip to the next team.
+Citation
+
+Yao Yan, Walter Reade, Elizabeth Park. Predicting Irrigation Need. https://kaggle.com/competitions/playground-series-s6e4, 2026. Kaggle.
+
+
+Dataset Description
+
+The dataset for this competition (both train and test) was generated from a deep learning model trained on the Irrigation Prediction dataset. Feature distributions are close to, but not exactly the same, as the original. Feel free to use the original dataset as part of this competition, both to explore differences as well as to see whether incorporating the original in training improves model performance.
+Files
+
+    train.csv - the training set, with Irrigation_Need as target
+    test.csv - the test set, used to predict the category for Irrigation_Need
+    sample_submission.csv - a sample submission file in the correct format
+

--- a/Predicting Irrigation Need/artifacts/README.md
+++ b/Predicting Irrigation Need/artifacts/README.md
@@ -1,0 +1,12 @@
+# Artifacts
+
+Derived outputs belong here.
+
+Typical files:
+
+- validation prediction CSVs under `artifacts/experiment_runs/`
+- `data_profile.md`
+- `benchmark_summary.md`
+- `approach_memory.md`
+- `progress.png`
+- baseline comparison outputs such as `artifacts/baseline_catboost/*.csv`

--- a/Predicting Irrigation Need/artifacts/baseline_catboost/smoke_domain_v1_seed42.csv
+++ b/Predicting Irrigation Need/artifacts/baseline_catboost/smoke_domain_v1_seed42.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59ed04679494b25656529703660bcf7a931593ccdf22a1b0da3ce76aedeba716
+size 239715

--- a/Predicting Irrigation Need/artifacts/baseline_catboost/smoke_raw_seed42.csv
+++ b/Predicting Irrigation Need/artifacts/baseline_catboost/smoke_raw_seed42.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8bf83cfca92af2608c737609a0d0e83116e71bd860bf033c08514e9666ea57d0
+size 239684

--- a/Predicting Irrigation Need/artifacts/experiment_runs/README.md
+++ b/Predicting Irrigation Need/artifacts/experiment_runs/README.md
@@ -1,0 +1,5 @@
+# Experiment Runs
+
+The fixed harness writes benchmark validation prediction CSVs here.
+
+Each file should correspond to one logged run in `results.tsv`.

--- a/Predicting Irrigation Need/artifacts/ideas.md
+++ b/Predicting Irrigation Need/artifacts/ideas.md
@@ -1,0 +1,11 @@
+# Ideas for Next Experiments
+
+Agents: append your ideas here. Mark them [tried] once tested.
+
+- Stacking: use CatBoost/LightGBM/XGBoost predictions as features into a logistic regression or ridge meta-learner (instead of simple averaging).
+- Optuna hyperparameter search on the best single model (catboost_v12) — focus on depth, learning_rate, l2_leaf_reg, bagging_temperature.
+- Original dataset: the competition mentions a source dataset. Download it and concatenate with the synthetic train data (with a `is_original` flag feature).
+- More aggressive High-class weighting: current best uses logit/digit thresholds. Try SMOTE oversampling for High class instead.
+- K-fold cross-validation: train with 5-fold CV on `full` benchmark, average predictions. Reduces variance.
+- Feature selection: use SHAP importance from catboost_v12 to drop noisy features and retrain.
+- Neural network: a small tabular MLP (2-3 hidden layers) as an additional ensemble member.

--- a/Predicting Irrigation Need/artifacts/subset_10pct.csv
+++ b/Predicting Irrigation Need/artifacts/subset_10pct.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c028211a5db3e3cc932ceb6c7e932e0ca8c87274ec61243301026ff36c7a7fe6
+size 8010229

--- a/Predicting Irrigation Need/artifacts/subset_1pct.csv
+++ b/Predicting Irrigation Need/artifacts/subset_1pct.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0f164125473f0124f6a121419f7a0389f7fd56ada6d3c8a9536d6ff0aa52302
+size 801178

--- a/Predicting Irrigation Need/artifacts/train_10pct.csv
+++ b/Predicting Irrigation Need/artifacts/train_10pct.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c028211a5db3e3cc932ceb6c7e932e0ca8c87274ec61243301026ff36c7a7fe6
+size 8010229

--- a/Predicting Irrigation Need/artifacts/train_1pct.csv
+++ b/Predicting Irrigation Need/artifacts/train_1pct.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0f164125473f0124f6a121419f7a0389f7fd56ada6d3c8a9536d6ff0aa52302
+size 801178

--- a/Predicting Irrigation Need/benchmark/holdout_v1/README.md
+++ b/Predicting Irrigation Need/benchmark/holdout_v1/README.md
@@ -1,0 +1,21 @@
+# Holdout Benchmark v1
+
+- Source of truth: `spec.json` and `splits.csv`
+- Metric: balanced accuracy
+- Labels: `Low`, `Medium`, `High`
+- Contract for predictions: CSV with columns `id,Irrigation_Need`
+
+Usage rules:
+
+- Use `smoke` for fast iteration.
+- Use `full` to confirm a promising result.
+- Model code should live under `src/`.
+- Model outputs should go under `artifacts/`.
+- Treat files under `benchmark/holdout_v1/` and `src/benchmark.py` as fixed benchmark infrastructure.
+
+Recommended workflow:
+
+1. Generate or refresh the benchmark once: `uv run python src/benchmark.py init`
+2. Inspect the split: `uv run python src/benchmark.py describe`
+3. Train a model against `smoke` or `full`
+4. Score its validation predictions with `uv run python src/benchmark.py score --benchmark <name> --predictions <csv>`

--- a/Predicting Irrigation Need/benchmark/holdout_v1/spec.json
+++ b/Predicting Irrigation Need/benchmark/holdout_v1/spec.json
@@ -1,0 +1,15 @@
+{
+  "version": "holdout_v1",
+  "metric": "balanced_accuracy",
+  "seed": 42,
+  "valid_fraction": 0.2,
+  "smoke_train_rows": 80000,
+  "smoke_valid_rows": 20000,
+  "target": "Irrigation_Need",
+  "id_column": "id",
+  "labels": [
+    "Low",
+    "Medium",
+    "High"
+  ]
+}

--- a/Predicting Irrigation Need/benchmark/holdout_v1/splits.csv
+++ b/Predicting Irrigation Need/benchmark/holdout_v1/splits.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3aa6dcd4de87eddfbd3be668c56613b23498b94f3675512e26a7c54b10bde52
+size 12388921

--- a/Predicting Irrigation Need/data/sample_submission.csv
+++ b/Predicting Irrigation Need/data/sample_submission.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa7592e34a364d64a84cd5bed873cb2ede59d9320438264963500d0f60fa39a4
+size 2970019

--- a/Predicting Irrigation Need/data/test.csv
+++ b/Predicting Irrigation Need/data/test.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9104cb493740caf34dabdd3b782fdc937d35269f5b728b966810ee499fc512ab
+size 32975070

--- a/Predicting Irrigation Need/data/train.csv
+++ b/Predicting Irrigation Need/data/train.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:feb2c63e38d62f377fb58c742cc7d2a9b2e242c6e8ee012e4182cd4d57595cba
+size 80091580

--- a/Predicting Irrigation Need/history/README.md
+++ b/Predicting Irrigation Need/history/README.md
@@ -1,0 +1,11 @@
+# History
+
+Each harness run can archive a snapshot here.
+
+Typical files per run directory:
+
+- `summary.json`
+- the exact `src/experiment.py` used for the run
+- the validation prediction CSV
+- the submission CSV, if one was written
+- the latest `artifacts/data_profile.md`, if present

--- a/Predicting Irrigation Need/logs/README.md
+++ b/Predicting Irrigation Need/logs/README.md
@@ -1,0 +1,7 @@
+# Logs
+
+Store baseline and experiment logs here, for example:
+
+- `profile.log`
+- `baseline.log`
+- `run.log`

--- a/Predicting Irrigation Need/notebooks/exploratory.ipynb
+++ b/Predicting Irrigation Need/notebooks/exploratory.ipynb
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c66ef5ef4425b797b8c71c29fc2f5848b69bd359552441ad031f37f9f130205
-size 8579
+oid sha256:98660bf4c4edda9b5e7771ec5ccaddaafbfd0bf3ef21da17728bfede581f59a9
+size 8582

--- a/Predicting Irrigation Need/notebooks/exploratory.ipynb
+++ b/Predicting Irrigation Need/notebooks/exploratory.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c66ef5ef4425b797b8c71c29fc2f5848b69bd359552441ad031f37f9f130205
+size 8579

--- a/Predicting Irrigation Need/program.md
+++ b/Predicting Irrigation Need/program.md
@@ -1,0 +1,226 @@
+# Predicting Irrigation Need Agent Workflow
+
+This competition uses a Kaggle-style adaptation of the `autoresearch` loop.
+
+The key difference from LLM training repos is that the agent must understand the dataset and the fixed benchmark split before it starts editing model code.
+
+## Files In Scope
+
+- `README.md` — Kaggle brief plus a benchmark block refreshed from `results.tsv`.
+- `AGENTS.md` — local operating rules.
+- `program.md` — this workflow.
+- `src/profile_data.py` — fixed data-understanding script.
+- `src/benchmark.py` — fixed benchmark infrastructure.
+- `benchmark/holdout_v1/` — fixed benchmark split artifacts.
+- `src/evaluate.py` — fixed experiment harness.
+- `src/experiment.py` — the primary agent-owned modeling surface.
+- `src/baseline_catboost.py` — reference baseline, not the default experiment surface.
+- `src/leaderboard.py` — ranks prediction CSVs already written under `artifacts/`.
+- `src/analyze_results.py` — refreshes benchmark summaries, progress plots, and approach memory from `results.tsv`.
+- `results.tsv` — auto-appended experiment log.
+- `history/` — archived per-run snapshots.
+- `artifacts/approach_memory.md` — generated memory of tried approaches and their outcomes.
+- `DIARY.md` — human-readable research notes.
+- `DOCKER.md` and `run_agent_container.sh` — optional container guardrails.
+
+## Setup
+
+Before the autonomous loop starts:
+
+1. Read `README.md`, `AGENTS.md`, `program.md`, `src/profile_data.py`, `src/benchmark.py`, `src/evaluate.py`, and `src/experiment.py`.
+2. Verify the competition data exists:
+   - `data/train.csv`
+   - `data/test.csv`
+   - `data/sample_submission.csv`
+3. If you want stronger filesystem guardrails, start the optional container shell with `bash run_agent_container.sh`.
+4. Verify the fixed benchmark split exists. If not, initialize it once:
+
+```bash
+uv run python src/benchmark.py init
+```
+
+5. Inspect the benchmark split:
+
+```bash
+uv run python src/benchmark.py describe
+```
+
+6. Run the data profile first:
+
+```bash
+uv run python src/profile_data.py > logs/profile.log 2>&1
+```
+
+7. Read `artifacts/data_profile.md` and `artifacts/approach_memory.md` before changing `src/experiment.py`.
+8. Run the baseline once on `smoke`:
+
+```bash
+EXPERIMENT_DESCRIPTION="baseline" uv run python src/evaluate.py --benchmark smoke > logs/baseline.log 2>&1
+```
+
+9. Read the summary lines from the log:
+
+```bash
+rg "^(run_id|benchmark|metric_name|metric_direction|metric_value|runtime_seconds|validation_predictions|submission_file|experiment|description|snapshot):" logs/baseline.log
+```
+
+10. Refresh the analysis outputs, approach memory, and README benchmark block:
+
+```bash
+uv run python src/analyze_results.py
+```
+
+## What The Agent Can Edit
+
+- Default to `src/experiment.py`.
+- Keep any extra helper modules under `src/` small and justified.
+
+## What The Agent Must Not Edit
+
+- `data/`
+- `src/benchmark.py`
+- `benchmark/holdout_v1/`
+- `src/profile_data.py`
+- `src/evaluate.py`
+- the human-authored narrative in `README.md`
+- `program.md`
+- `AGENTS.md`
+- root `pyproject.toml`
+- root `uv.lock`
+
+## Experiment Loop
+
+Repeat until interrupted:
+
+1. Re-read `artifacts/data_profile.md` and inspect the current branch and last winning commit.
+2. Make one experiment-sized change in `src/experiment.py`.
+   Update `experiment.APPROACH` and `experiment.DESCRIPTION` so the idea is logged clearly.
+3. Create a commit for that candidate.
+4. Run the harness with a short note:
+
+```bash
+EXPERIMENT_DESCRIPTION="your idea here" uv run python src/evaluate.py --benchmark smoke > logs/run.log 2>&1
+```
+
+5. Extract the summary:
+
+```bash
+rg "^(run_id|benchmark|metric_name|metric_direction|metric_value|runtime_seconds|validation_predictions|submission_file|experiment|description|snapshot):" logs/run.log
+```
+
+6. If the summary is missing, inspect the crash:
+
+```bash
+tail -n 50 logs/run.log
+```
+
+7. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
+8. Update the `status` in `results.tsv` to `keep`, `discard`, or `crash` after the decision.
+9. Refresh the analysis outputs and approach memory:
+
+```bash
+uv run python src/analyze_results.py
+```
+
+10. If a `smoke` result looks promising, confirm it on `full` before treating it as the new headline benchmark.
+11. Keep the commit only if the benchmark improved enough to justify the complexity.
+
+## Output Contract
+
+`src/evaluate.py` prints a machine-readable summary block like this:
+
+```text
+---
+run_id:                 20260427-101530-a1b2c3d
+benchmark:              smoke
+metric_name:            balanced_accuracy
+metric_direction:       maximize
+metric_value:           0.587170
+runtime_seconds:        2.4
+validation_predictions: artifacts/experiment_runs/20260427-101530-a1b2c3d-smoke.csv
+submission_file:        submissions/submission-20260427-101530-a1b2c3d.csv
+experiment:             majority-class baseline
+description:            baseline
+snapshot:               history/20260427-101530-a1b2c3d
+```
+
+## Auto-Recorded Results
+
+The harness auto-appends `results.tsv` using tab-separated values:
+
+```tsv
+run_id	commit	benchmark	approach	metric_name	metric_direction	metric_value	runtime_seconds	status	description	snapshot
+```
+
+It also writes `history/<run_id>/summary.json` and copies the exact `src/experiment.py` used for that run.
+
+## Approach Memory
+
+`src/analyze_results.py` writes `artifacts/approach_memory.md`, which summarizes:
+
+- best current approaches by benchmark
+- approaches worth building on
+- discarded or crashed approaches worth avoiding
+- recent runs with their evaluation outcomes
+
+Read it before the next iteration so the agent can build on prior wins and avoid repeating the same mistake.
+
+## README Benchmark Block
+
+`README.md` should explain the competition and also show the best current benchmark.
+
+Use this marker block:
+
+```md
+<!-- benchmark:start -->
+...
+<!-- benchmark:end -->
+```
+
+`src/analyze_results.py` refreshes that block from `results.tsv` when `README.md` is writable. It always writes `artifacts/benchmark_summary.md`.
+
+## Safety Rules
+
+- Treat `data/` as read-only.
+- Do not skip the data-understanding step.
+- Treat `src/benchmark.py` and `benchmark/holdout_v1/` as fixed scoring infrastructure.
+- Use as many CPU cores as possible whenever the training library supports it, unless there is a concrete reason not to.
+- Use `smoke` for quick iteration and `full` to confirm promising changes.
+- When the dataset is too large for fast iteration, debug and test on `smoke` or another smaller stratified subset first, then confirm on the full fixed benchmark.
+- If you need stronger guardrails, run the loop inside the optional Docker wrapper so protected files are mounted read-only.
+- Review the archived snapshot before deciding to keep or discard a run.
+- Use `data/sample_submission.csv` as the submission schema.
+- Do not create a new submission file unless the run completed successfully.
+- Prefer smaller, reviewable edits over large rewrites.
+- Each experiment run must complete within **15 minutes** wall-clock time. If a run exceeds this, reduce the training data size or iteration count before retrying.
+
+## Faster Iteration
+
+Training on the full 630K-row dataset is expensive. Use these strategies to keep the feedback loop tight.
+
+### Stratified Micro-Subsets
+
+For rapid feature engineering and hyperparameter experiments, extract a small stratified subset of the training data that preserves the target class distribution. Suggested sizes:
+
+- **1 % subset** (~6 300 rows): for sanity-checking code paths and quick feature iterations.
+- **10 % subset** (~63 000 rows): for more reliable signal before committing to a full `smoke` or `full` run.
+
+Create a subset once and cache it (e.g. under `artifacts/`) so repeated runs skip the resampling. Always stratify on `Irrigation_Need` so the severe class imbalance (High ≈ 3.3 %) is faithfully represented.
+
+Workflow:
+
+1. Develop and debug on the 1 % subset.
+2. Promising changes → validate on the 10 % subset or `smoke`.
+3. Best candidates → confirm on `full`.
+
+### Hardware Acceleration
+
+Prefer libraries that exploit multi-core CPUs and SIMD instructions out of the box (CatBoost, LightGBM, XGBoost already do). For custom feature-engineering or post-processing code that is still a bottleneck:
+
+- **Numba**: JIT-compile pure-Python numeric loops with `@njit(parallel=True)` and `prange`. Especially effective for row-wise feature transforms that Polars expressions cannot express natively.
+- **NumPy vectorisation**: replace Python-level loops with broadcast operations before reaching for Numba.
+- **Polars lazy**: use `pl.LazyFrame` and `collect()` to let the query optimizer fuse and parallelise transformations.
+- **Mixed-precision arithmetic**: Polars defaults to `Float64`. Most features in this dataset do not require double precision. Cast to `Float32` (`.cast(pl.Float32)`) after computation to halve memory and speed up downstream operations. GBM libraries internally use 32-bit floats anyway, so the extra precision is wasted.
+- **Chunked processing**: When working with the full dataset, process data in chunks (e.g. via `pl.read_csv(..., n_rows=chunk_size)` in a loop or by slicing an in-memory frame) to keep peak RAM usage bounded. This has not been a bottleneck so far, but it is good hygiene for larger feature sets.
+
+Only introduce Numba (or similar) if profiling shows that the feature-engineering step dominates runtime. Do not add it speculatively.

--- a/Predicting Irrigation Need/program.md
+++ b/Predicting Irrigation Need/program.md
@@ -20,6 +20,7 @@ The key difference from LLM training repos is that the agent must understand the
 - `results.tsv` — auto-appended experiment log.
 - `history/` — archived per-run snapshots.
 - `artifacts/approach_memory.md` — generated memory of tried approaches and their outcomes.
+- `artifacts/ideas.md` — agent-editable list of experiment ideas. Append new ideas; mark them `[tried]` once tested.
 - `DIARY.md` — human-readable research notes.
 - `DOCKER.md` and `run_agent_container.sh` — optional container guardrails.
 
@@ -51,7 +52,7 @@ uv run python src/benchmark.py describe
 uv run python src/profile_data.py > logs/profile.log 2>&1
 ```
 
-7. Read `artifacts/data_profile.md` and `artifacts/approach_memory.md` before changing `src/experiment.py`.
+7. Read `artifacts/data_profile.md`, `artifacts/approach_memory.md`, and `artifacts/ideas.md` before changing `src/experiment.py`.
 8. Run the baseline once on `smoke`:
 
 ```bash
@@ -92,7 +93,8 @@ uv run python src/analyze_results.py
 
 Repeat until interrupted:
 
-1. Re-read `artifacts/data_profile.md` and inspect the current branch and last winning commit.
+1. Re-read `artifacts/data_profile.md` and `artifacts/approach_memory.md` — compare the best scores there against your new idea to avoid repeating discarded approaches.
+2. Check `artifacts/ideas.md` for untried experiment ideas. Pick one or add your own. Mark it `[tried]` when you start.
 2. Make one experiment-sized change in `src/experiment.py`.
    Update `experiment.APPROACH` and `experiment.DESCRIPTION` so the idea is logged clearly.
 3. Create a commit for that candidate.
@@ -116,7 +118,7 @@ tail -n 50 logs/run.log
 
 7. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
 8. Update the `status` in `results.tsv` to `keep`, `discard`, or `crash` after the decision.
-9. Refresh the analysis outputs and approach memory:
+9. Refresh the analysis outputs, approach memory, and ideas:
 
 ```bash
 uv run python src/analyze_results.py

--- a/Predicting Irrigation Need/run_agent_container.sh
+++ b/Predicting Irrigation Need/run_agent_container.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+competition_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${competition_dir}/.." && pwd)"
+
+mkdir -p \
+  "${competition_dir}/artifacts" \
+  "${competition_dir}/history" \
+  "${competition_dir}/logs" \
+  "${competition_dir}/submissions"
+
+docker run --rm -it \
+  --workdir /workspace/competition \
+  --mount type=bind,src="${competition_dir}",dst=/workspace/competition \
+  --mount type=bind,src="${repo_root}",dst=/repo,readonly \
+  --mount type=bind,src="${competition_dir}/AGENTS.md",dst=/workspace/competition/AGENTS.md,readonly \
+  --mount type=bind,src="${competition_dir}/README.md",dst=/workspace/competition/README.md,readonly \
+  --mount type=bind,src="${competition_dir}/program.md",dst=/workspace/competition/program.md,readonly \
+  --mount type=bind,src="${competition_dir}/data",dst=/workspace/competition/data,readonly \
+  --mount type=bind,src="${competition_dir}/benchmark/holdout_v1",dst=/workspace/competition/benchmark/holdout_v1,readonly \
+  --mount type=bind,src="${competition_dir}/src/benchmark.py",dst=/workspace/competition/src/benchmark.py,readonly \
+  --mount type=bind,src="${competition_dir}/src/evaluate.py",dst=/workspace/competition/src/evaluate.py,readonly \
+  --mount type=bind,src="${competition_dir}/src/profile_data.py",dst=/workspace/competition/src/profile_data.py,readonly \
+  --mount type=volume,src=kaggle-agent-uv-cache,dst=/root/.cache/uv \
+  ghcr.io/astral-sh/uv:python3.13-bookworm \
+  bash -lc 'export UV_PROJECT_ENVIRONMENT=/workspace/competition/.venv; uv sync --frozen; exec bash'

--- a/Predicting Irrigation Need/src/analyze_results.py
+++ b/Predicting Irrigation Need/src/analyze_results.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+from benchmark import PROJECT_ROOT
+
+RESULTS_PATH = PROJECT_ROOT / "results.tsv"
+ARTIFACT_DIR = PROJECT_ROOT / "artifacts"
+README_PATH = PROJECT_ROOT / "README.md"
+
+
+def main() -> None:
+    ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+    if not RESULTS_PATH.exists():
+        raise FileNotFoundError(f"Missing {RESULTS_PATH}")
+
+    results = pl.read_csv(RESULTS_PATH, separator="\t")
+    if results.is_empty():
+        write_placeholder_outputs()
+        print("No experiment rows logged yet.")
+        return
+
+    results = results.with_columns(
+        pl.col("status").cast(pl.Utf8).str.to_uppercase(),
+        pl.col("benchmark").cast(pl.Utf8).str.to_lowercase(),
+        pl.col("metric_direction").cast(pl.Utf8).str.to_lowercase(),
+        pl.col("metric_value").cast(pl.Float64),
+        pl.col("runtime_seconds").cast(pl.Float64),
+        pl.int_range(pl.len()).alias("experiment_index"),
+    )
+
+    non_crash = results.filter(pl.col("status") != "CRASH")
+    accepted = results.filter(pl.col("status").is_in(["KEEP", "RAN"]))
+    preferred = accepted if accepted.height else non_crash
+    metric_name = results.item(0, "metric_name")
+    metric_direction = results.item(0, "metric_direction")
+
+    print(f"Total runs: {results.height}")
+    print(results.group_by("status").len().sort("status"))
+
+    plot_progress(non_crash, metric_name, metric_direction)
+    benchmark_summary = render_benchmark_summary(preferred, metric_name, metric_direction)
+    (ARTIFACT_DIR / "benchmark_summary.md").write_text(benchmark_summary, encoding="utf-8")
+
+    approach_memory = render_approach_memory(results, preferred, metric_direction)
+    (ARTIFACT_DIR / "approach_memory.md").write_text(approach_memory, encoding="utf-8")
+
+    if update_readme_benchmark_block(README_PATH, benchmark_summary):
+        print(f"Updated {README_PATH.relative_to(PROJECT_ROOT)} benchmark block")
+    else:
+        print("Skipped README benchmark update")
+
+    print(f"Saved {(ARTIFACT_DIR / 'benchmark_summary.md').relative_to(PROJECT_ROOT)}")
+    print(f"Saved {(ARTIFACT_DIR / 'approach_memory.md').relative_to(PROJECT_ROOT)}")
+    print(f"Saved {(ARTIFACT_DIR / 'progress.png').relative_to(PROJECT_ROOT)}")
+
+
+def write_placeholder_outputs() -> None:
+    placeholder = "- No successful runs logged yet.\n"
+    (ARTIFACT_DIR / "benchmark_summary.md").write_text(placeholder, encoding="utf-8")
+    (ARTIFACT_DIR / "approach_memory.md").write_text("# Approach Memory\n\n- No approaches logged yet.\n", encoding="utf-8")
+    update_readme_benchmark_block(README_PATH, placeholder)
+
+
+def plot_progress(results: pl.DataFrame, metric_name: str, metric_direction: str) -> None:
+    fig, ax = plt.subplots(figsize=(14, 7))
+    colors = {"smoke": "#1f77b4", "full": "#d62728"}
+
+    for benchmark_name in sorted(set(results["benchmark"].to_list())):
+        subset = results.filter(pl.col("benchmark") == benchmark_name).sort("experiment_index")
+        if subset.is_empty():
+            continue
+
+        x = subset["experiment_index"].to_list()
+        y = subset["metric_value"].to_list()
+        running = running_best(y, metric_direction)
+        ax.scatter(x, y, s=28, alpha=0.7, label=f"{benchmark_name} score", color=colors.get(benchmark_name))
+        ax.plot(x, running, linewidth=2, label=f"{benchmark_name} best", color=colors.get(benchmark_name))
+
+    ax.set_title(f"Benchmark Progress ({metric_name}, {metric_direction})")
+    ax.set_xlabel("Experiment #")
+    ax.set_ylabel(metric_name)
+    ax.grid(alpha=0.2)
+    ax.legend()
+    plt.tight_layout()
+    plt.savefig(ARTIFACT_DIR / "progress.png", dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def render_benchmark_summary(results: pl.DataFrame, metric_name: str, metric_direction: str) -> str:
+    lines = [
+        f"- Metric: `{metric_name}` (`{metric_direction}`)",
+        f"- Total logged runs: `{results.height}`",
+    ]
+
+    for benchmark_name in ("full", "smoke"):
+        subset = results.filter(pl.col("benchmark") == benchmark_name)
+        if subset.is_empty():
+            lines.append(f"- Best {benchmark_name}: not run yet")
+            continue
+
+        best_row = best_row_for_metric(subset, metric_direction)
+        lines.append(
+            f"- Best {benchmark_name}: `{float(best_row['metric_value']):.6f}` via `{best_row['approach']}` "
+            f"(`{best_row['status'].lower()}`; run `{best_row['run_id']}`)"
+        )
+
+    lines.append(f"- Last updated: {datetime.now(UTC).strftime('%Y-%m-%d %H:%M UTC')}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_approach_memory(results: pl.DataFrame, preferred: pl.DataFrame, metric_direction: str) -> str:
+    lines = ["# Approach Memory", "", "Read this before the next experiment.", ""]
+
+    lines.extend(["## Best Current Approaches", ""])
+    for benchmark_name in ("full", "smoke"):
+        subset = preferred.filter(pl.col("benchmark") == benchmark_name)
+        if subset.is_empty():
+            lines.append(f"- `{benchmark_name}`: no accepted runs yet")
+            continue
+        best_row = best_row_for_metric(subset, metric_direction)
+        lines.append(
+            f"- `{benchmark_name}`: `{best_row['approach']}` -> {float(best_row['metric_value']):.6f} "
+            f"[{best_row['status'].lower()}] | {best_row['description']} | run `{best_row['run_id']}`"
+        )
+    lines.append("")
+
+    build_on = results.filter(pl.col("status").is_in(["KEEP", "RAN"]))
+    lines.extend(["## Build On", ""])
+    if build_on.is_empty():
+        lines.append("- No accepted runs yet.")
+    else:
+        for row in top_rows(build_on, metric_direction, limit=5):
+            lines.append(
+                f"- `{row['benchmark']}` | `{row['approach']}` | {float(row['metric_value']):.6f} | "
+                f"{row['description']} | run `{row['run_id']}`"
+            )
+    lines.append("")
+
+    avoid = results.filter(pl.col("status").is_in(["DISCARD", "CRASH"])).sort("experiment_index", descending=True)
+    lines.extend(["## Avoid Repeating", ""])
+    if avoid.is_empty():
+        lines.append("- No discarded or crashed runs logged yet.")
+    else:
+        for row in avoid.head(8).iter_rows(named=True):
+            lines.append(
+                f"- `{row['benchmark']}` | `{row['approach']}` | {row['status'].lower()} | "
+                f"{float(row['metric_value']):.6f} | {row['description']} | run `{row['run_id']}`"
+            )
+    lines.append("")
+
+    lines.extend(["## Recent Runs", ""])
+    for row in results.sort("experiment_index", descending=True).head(10).iter_rows(named=True):
+        lines.append(
+            f"- `{row['benchmark']}` | `{row['approach']}` | {float(row['metric_value']):.6f} | "
+            f"{row['status'].lower()} | {row['description']} | run `{row['run_id']}`"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def top_rows(results: pl.DataFrame, metric_direction: str, limit: int) -> list[dict[str, object]]:
+    descending = metric_direction == "maximize"
+    return results.sort("metric_value", descending=descending).head(limit).iter_rows(named=True)
+
+
+def best_row_for_metric(results: pl.DataFrame, metric_direction: str) -> dict[str, object]:
+    descending = metric_direction == "maximize"
+    return results.sort("metric_value", descending=descending).row(0, named=True)
+
+
+def running_best(values: list[float], metric_direction: str) -> list[float]:
+    best_values: list[float] = []
+    current = values[0]
+    for value in values:
+        if metric_direction == "maximize":
+            current = max(current, value)
+        else:
+            current = min(current, value)
+        best_values.append(current)
+    return best_values
+
+
+def update_readme_benchmark_block(readme_path: Path, benchmark_summary: str) -> bool:
+    if not readme_path.exists() or not readme_path.is_file():
+        return False
+
+    start_marker = "<!-- benchmark:start -->"
+    end_marker = "<!-- benchmark:end -->"
+    readme_text = readme_path.read_text(encoding="utf-8")
+    if start_marker not in readme_text or end_marker not in readme_text:
+        return False
+
+    start_index = readme_text.index(start_marker) + len(start_marker)
+    end_index = readme_text.index(end_marker)
+    updated_text = readme_text[:start_index] + f"\n{benchmark_summary}" + readme_text[end_index:]
+    try:
+        readme_path.write_text(updated_text, encoding="utf-8")
+    except OSError:
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/Predicting Irrigation Need/src/analyze_results.py
+++ b/Predicting Irrigation Need/src/analyze_results.py
@@ -161,6 +161,17 @@ def render_approach_memory(results: pl.DataFrame, preferred: pl.DataFrame, metri
             f"{row['status'].lower()} | {row['description']} | run `{row['run_id']}`"
         )
     lines.append("")
+
+    ideas_path = ARTIFACT_DIR / "ideas.md"
+    lines.extend(["## Ideas for Next Experiments", ""])
+    if ideas_path.exists():
+        for idea_line in ideas_path.read_text(encoding="utf-8").strip().splitlines():
+            if idea_line.strip() and not idea_line.startswith("#"):
+                lines.append(idea_line)
+    else:
+        lines.append("- No ideas logged yet. Add them to `artifacts/ideas.md`.")
+    lines.append("")
+
     return "\n".join(lines)
 
 

--- a/Predicting Irrigation Need/src/baseline_catboost.py
+++ b/Predicting Irrigation Need/src/baseline_catboost.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import polars as pl
+from catboost import CatBoostClassifier
+
+from benchmark import ID_COLUMN, PROJECT_ROOT, TARGET, load_benchmark_part, score_prediction_frame
+
+ARTIFACTS_DIR = PROJECT_ROOT / "artifacts" / "baseline_catboost"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a CatBoost baseline against the fixed benchmark split.")
+    parser.add_argument("--benchmark", choices=("smoke", "full"), default="smoke")
+    parser.add_argument("--feature-set", choices=("raw", "domain_v1"), default="raw")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--iterations", type=int, default=600)
+    parser.add_argument("--output", help="Optional output path for validation predictions.")
+    return parser.parse_args()
+
+
+def add_domain_features(frame: pl.DataFrame) -> pl.DataFrame:
+    return frame.with_columns(
+        pl.when(pl.col("Crop_Growth_Stage") == "Sowing")
+        .then(0)
+        .when(pl.col("Crop_Growth_Stage") == "Vegetative")
+        .then(1)
+        .when(pl.col("Crop_Growth_Stage") == "Flowering")
+        .then(2)
+        .when(pl.col("Crop_Growth_Stage") == "Harvest")
+        .then(3)
+        .otherwise(None)
+        .cast(pl.Int64)
+        .alias("Crop_Growth_Stage_Ordinal"),
+        (pl.col("Temperature_C") * pl.col("Sunlight_Hours") * pl.col("Wind_Speed_kmh") / (pl.col("Humidity") + 1.0)).alias(
+            "Dryness_Index"
+        ),
+        (pl.col("Soil_Moisture") / (pl.col("Temperature_C") + 1.0)).alias("Moisture_Temperature_Ratio"),
+        ((pl.col("Rainfall_mm") + pl.col("Previous_Irrigation_mm")) / (pl.col("Sunlight_Hours") + 1.0)).alias(
+            "Water_Input_Per_Sunlight"
+        ),
+    )
+
+
+def build_feature_frame(frame: pl.DataFrame, feature_set: str) -> pl.DataFrame:
+    features = frame.drop(TARGET, ID_COLUMN)
+    if feature_set == "raw":
+        return features
+    if feature_set == "domain_v1":
+        return add_domain_features(features)
+    raise ValueError(f"Unknown feature set: {feature_set}")
+
+
+def to_pandas(frame: pl.DataFrame) -> pd.DataFrame:
+    return pd.DataFrame(frame.to_dict(as_series=False))
+
+
+def split_feature_columns(frame: pl.DataFrame) -> tuple[list[str], list[str]]:
+    numeric_columns = [name for name, dtype in frame.schema.items() if dtype.is_numeric()]
+    categorical_columns = [name for name in frame.columns if name not in numeric_columns]
+    return numeric_columns, categorical_columns
+
+
+def output_path_for(args: argparse.Namespace) -> Path:
+    if args.output:
+        return Path(args.output)
+    filename = f"{args.benchmark}_{args.feature_set}_seed{args.seed}.csv"
+    return ARTIFACTS_DIR / filename
+
+
+def main() -> None:
+    args = parse_args()
+    train_frame = load_benchmark_part(args.benchmark, "train")
+    valid_frame = load_benchmark_part(args.benchmark, "valid")
+
+    x_train_pl = build_feature_frame(train_frame, args.feature_set)
+    x_valid_pl = build_feature_frame(valid_frame, args.feature_set)
+    _, categorical_columns = split_feature_columns(x_train_pl)
+
+    x_train = to_pandas(x_train_pl)
+    x_valid = to_pandas(x_valid_pl)
+    y_train = train_frame[TARGET].to_list()
+
+    model = CatBoostClassifier(
+        loss_function="MultiClass",
+        auto_class_weights="Balanced",
+        depth=8,
+        learning_rate=0.05,
+        iterations=args.iterations,
+        random_seed=args.seed,
+        thread_count=-1,
+        allow_writing_files=False,
+        verbose=False,
+    )
+    model.fit(x_train, y_train, cat_features=categorical_columns, eval_set=(x_valid, valid_frame[TARGET].to_list()), use_best_model=True)
+
+    predictions = model.predict(x_valid).ravel().tolist()
+    prediction_frame = pl.DataFrame({ID_COLUMN: valid_frame[ID_COLUMN].to_list(), TARGET: predictions})
+
+    output_path = output_path_for(args)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    prediction_frame.write_csv(output_path)
+
+    metrics = score_prediction_frame(prediction_frame, args.benchmark)
+    print(f"Wrote predictions to {output_path}")
+    print(pl.DataFrame([metrics]).with_columns(pl.exclude(["benchmark", "rows"]).round(6)))
+
+
+if __name__ == "__main__":
+    main()

--- a/Predicting Irrigation Need/src/benchmark.py
+++ b/Predicting Irrigation Need/src/benchmark.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import polars as pl
+from sklearn.metrics import balanced_accuracy_score, classification_report
+from sklearn.model_selection import train_test_split
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = PROJECT_ROOT / "data"
+BENCHMARK_DIR = PROJECT_ROOT / "benchmark" / "holdout_v1"
+SPEC_PATH = BENCHMARK_DIR / "spec.json"
+SPLIT_PATH = BENCHMARK_DIR / "splits.csv"
+
+TARGET = "Irrigation_Need"
+ID_COLUMN = "id"
+TARGET_LABELS = ["Low", "Medium", "High"]
+BENCHMARK_NAMES = ("full", "smoke")
+
+DEFAULT_SPEC = {
+    "version": "holdout_v1",
+    "metric": "balanced_accuracy",
+    "seed": 42,
+    "valid_fraction": 0.2,
+    "smoke_train_rows": 80000,
+    "smoke_valid_rows": 20000,
+    "target": TARGET,
+    "id_column": ID_COLUMN,
+    "labels": TARGET_LABELS,
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fixed benchmark utilities for irrigation modeling experiments.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create the fixed benchmark split artifacts.")
+    init_parser.add_argument("--force", action="store_true", help="Overwrite existing split artifacts.")
+
+    subparsers.add_parser("describe", help="Describe the benchmark split artifacts.")
+
+    template_parser = subparsers.add_parser("template", help="Write a prediction template for a benchmark validation split.")
+    template_parser.add_argument("--benchmark", choices=BENCHMARK_NAMES, default="smoke")
+    template_parser.add_argument("--output", required=True, help="Where to write the template CSV.")
+
+    score_parser = subparsers.add_parser("score", help="Score a predictions CSV against a benchmark validation split.")
+    score_parser.add_argument("--benchmark", choices=BENCHMARK_NAMES, default="smoke")
+    score_parser.add_argument("--predictions", required=True, help="CSV with columns id,Irrigation_Need.")
+
+    return parser.parse_args()
+
+
+def load_spec() -> dict[str, object]:
+    if SPEC_PATH.exists():
+        return json.loads(SPEC_PATH.read_text())
+    return DEFAULT_SPEC.copy()
+
+
+def load_train_frame() -> pl.DataFrame:
+    return pl.read_csv(DATA_DIR / "train.csv")
+
+
+def benchmark_split_column(benchmark_name: str) -> str:
+    if benchmark_name == "full":
+        return "benchmark_split"
+    if benchmark_name == "smoke":
+        return "smoke_split"
+    raise ValueError(f"Unknown benchmark name: {benchmark_name}")
+
+
+def stratified_subset(indices: list[int], labels: list[str], subset_rows: int, seed: int) -> list[int]:
+    if subset_rows >= len(indices):
+        return indices
+    sampled_indices, _ = train_test_split(indices, train_size=subset_rows, stratify=labels, random_state=seed)
+    return list(sampled_indices)
+
+
+def create_split_frame(train_frame: pl.DataFrame, spec: dict[str, object]) -> pl.DataFrame:
+    seed = int(spec["seed"])
+    valid_fraction = float(spec["valid_fraction"])
+    smoke_train_rows = int(spec["smoke_train_rows"])
+    smoke_valid_rows = int(spec["smoke_valid_rows"])
+
+    row_indices = list(range(train_frame.height))
+    labels = train_frame[TARGET].to_list()
+    train_indices, valid_indices = train_test_split(
+        row_indices,
+        test_size=valid_fraction,
+        stratify=labels,
+        random_state=seed,
+    )
+
+    train_labels = [labels[index] for index in train_indices]
+    valid_labels = [labels[index] for index in valid_indices]
+    smoke_train_indices = stratified_subset(train_indices, train_labels, smoke_train_rows, seed + 1)
+    smoke_valid_indices = stratified_subset(valid_indices, valid_labels, smoke_valid_rows, seed + 2)
+
+    benchmark_split = ["train"] * train_frame.height
+    smoke_split = ["unused"] * train_frame.height
+    for index in valid_indices:
+        benchmark_split[index] = "valid"
+    for index in smoke_train_indices:
+        smoke_split[index] = "train"
+    for index in smoke_valid_indices:
+        smoke_split[index] = "valid"
+
+    return pl.DataFrame(
+        {
+            ID_COLUMN: train_frame[ID_COLUMN].to_list(),
+            "benchmark_split": benchmark_split,
+            "smoke_split": smoke_split,
+        }
+    ).sort(ID_COLUMN)
+
+
+def ensure_benchmark_exists() -> None:
+    if not SPEC_PATH.exists() or not SPLIT_PATH.exists():
+        raise FileNotFoundError(
+            "Benchmark artifacts are missing. Run `uv run python src/benchmark.py init` first."
+        )
+
+
+def load_split_frame() -> pl.DataFrame:
+    ensure_benchmark_exists()
+    return pl.read_csv(SPLIT_PATH)
+
+
+def write_split_artifacts(force: bool) -> None:
+    BENCHMARK_DIR.mkdir(parents=True, exist_ok=True)
+    if not force and (SPEC_PATH.exists() or SPLIT_PATH.exists()):
+        raise FileExistsError("Benchmark artifacts already exist. Use --force to overwrite them.")
+
+    spec = DEFAULT_SPEC.copy()
+    train_frame = load_train_frame()
+    split_frame = create_split_frame(train_frame, spec)
+    SPEC_PATH.write_text(json.dumps(spec, indent=2) + "\n")
+    split_frame.write_csv(SPLIT_PATH)
+
+
+def load_benchmark_part(benchmark_name: str, part: str) -> pl.DataFrame:
+    if part not in {"train", "valid"}:
+        raise ValueError(f"Unknown benchmark part: {part}")
+
+    train_frame = load_train_frame()
+    split_frame = load_split_frame()
+    split_column = benchmark_split_column(benchmark_name)
+    selected_ids = split_frame.filter(pl.col(split_column) == part).select(ID_COLUMN)
+    return train_frame.join(selected_ids, on=ID_COLUMN, how="inner")
+
+
+def prediction_template(benchmark_name: str) -> pl.DataFrame:
+    valid_frame = load_benchmark_part(benchmark_name, "valid")
+    return valid_frame.select(ID_COLUMN).with_columns(pl.lit(TARGET_LABELS[0]).alias(TARGET))
+
+
+def summarize_predictions(y_true: list[str], y_pred: list[str]) -> dict[str, float]:
+    report = classification_report(y_true, y_pred, labels=TARGET_LABELS, output_dict=True, zero_division=0)
+    return {
+        "balanced_accuracy": balanced_accuracy_score(y_true, y_pred),
+        "recall_low": report["Low"]["recall"],
+        "recall_medium": report["Medium"]["recall"],
+        "recall_high": report["High"]["recall"],
+    }
+
+
+def score_prediction_frame(predictions: pl.DataFrame, benchmark_name: str) -> dict[str, float | int | str]:
+    if predictions.columns != [ID_COLUMN, TARGET]:
+        raise ValueError(f"Predictions must have columns exactly [{ID_COLUMN}, {TARGET}].")
+    if predictions[ID_COLUMN].n_unique() != predictions.height:
+        raise ValueError("Predictions contain duplicate ids.")
+
+    valid_frame = load_benchmark_part(benchmark_name, "valid").select(ID_COLUMN, TARGET)
+    extra_ids = predictions.join(valid_frame.select(ID_COLUMN), on=ID_COLUMN, how="anti")
+    if extra_ids.height > 0:
+        raise ValueError("Predictions contain ids outside the benchmark validation split.")
+
+    scored = valid_frame.join(predictions, on=ID_COLUMN, how="left", suffix="_pred")
+    if scored[f"{TARGET}_pred"].null_count() > 0:
+        raise ValueError("Predictions are missing ids from the benchmark validation split.")
+
+    invalid_labels = scored.filter(~pl.col(f"{TARGET}_pred").is_in(TARGET_LABELS))
+    if invalid_labels.height > 0:
+        raise ValueError(f"Predictions contain labels outside {TARGET_LABELS}.")
+
+    y_true = scored[TARGET].to_list()
+    y_pred = scored[f"{TARGET}_pred"].to_list()
+    metrics = summarize_predictions(y_true, y_pred)
+    return {
+        "benchmark": benchmark_name,
+        "rows": len(y_true),
+        **metrics,
+    }
+
+
+def describe_benchmark() -> None:
+    spec = load_spec()
+    train_frame = load_train_frame()
+    split_frame = load_split_frame()
+    print(json.dumps(spec, indent=2))
+
+    summary_rows: list[dict[str, object]] = []
+    for benchmark_name in BENCHMARK_NAMES:
+        split_column = benchmark_split_column(benchmark_name)
+        for part in ("train", "valid"):
+            part_ids = split_frame.filter(pl.col(split_column) == part).select(ID_COLUMN)
+            if part_ids.height == 0:
+                continue
+            part_frame = train_frame.join(part_ids, on=ID_COLUMN, how="inner")
+            target_shares = (
+                part_frame.group_by(TARGET)
+                .len()
+                .rename({"len": "count"})
+                .with_columns((pl.col("count") / pl.col("count").sum()).alias("share"))
+                .sort(TARGET)
+            )
+            shares = {row[TARGET]: row["share"] for row in target_shares.to_dicts()}
+            summary_rows.append(
+                {
+                    "benchmark": benchmark_name,
+                    "part": part,
+                    "rows": part_frame.height,
+                    "share_low": shares.get("Low", 0.0),
+                    "share_medium": shares.get("Medium", 0.0),
+                    "share_high": shares.get("High", 0.0),
+                }
+            )
+
+    print(
+        pl.DataFrame(summary_rows).with_columns(
+            pl.col("share_low").round(6),
+            pl.col("share_medium").round(6),
+            pl.col("share_high").round(6),
+        )
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "init":
+        write_split_artifacts(force=args.force)
+        describe_benchmark()
+        return
+
+    if args.command == "describe":
+        describe_benchmark()
+        return
+
+    if args.command == "template":
+        template = prediction_template(args.benchmark)
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        template.write_csv(output_path)
+        print(f"Wrote template to {output_path}")
+        return
+
+    if args.command == "score":
+        predictions = pl.read_csv(args.predictions)
+        metrics = score_prediction_frame(predictions, args.benchmark)
+        print(pl.DataFrame([metrics]).with_columns(pl.exclude(["benchmark", "rows"]).round(6)))
+        return
+
+    raise ValueError(f"Unknown command: {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Predicting Irrigation Need/src/evaluate.py
+++ b/Predicting Irrigation Need/src/evaluate.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import time
+
+import polars as pl
+
+import experiment
+from benchmark import (
+    BENCHMARK_NAMES,
+    DATA_DIR,
+    ID_COLUMN,
+    PROJECT_ROOT,
+    TARGET,
+    ensure_benchmark_exists,
+    load_benchmark_part,
+    load_train_frame,
+    score_prediction_frame,
+)
+
+METRIC_NAME = "balanced_accuracy"
+METRIC_DIRECTION = "maximize"
+RESULTS_PATH = PROJECT_ROOT / "results.tsv"
+RESULTS_HEADER = (
+    "run_id\tcommit\tbenchmark\tapproach\tmetric_name\tmetric_direction\tmetric_value\t"
+    "runtime_seconds\tstatus\tdescription\tsnapshot\n"
+)
+EXPERIMENT_RUNS_DIR = PROJECT_ROOT / "artifacts" / "experiment_runs"
+HISTORY_DIR = PROJECT_ROOT / "history"
+SUBMISSIONS_DIR = PROJECT_ROOT / "submissions"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the fixed irrigation benchmark harness against src/experiment.py.")
+    parser.add_argument("--benchmark", choices=BENCHMARK_NAMES, default="smoke")
+    parser.add_argument("--write-submission", action="store_true", help="Also fit on the full training set and write a Kaggle submission.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_benchmark_exists()
+
+    description = os.environ.get("EXPERIMENT_DESCRIPTION", "").strip() or experiment.DESCRIPTION
+    commit = git_short_commit(PROJECT_ROOT)
+    working_tree_dirty = git_is_dirty(PROJECT_ROOT)
+    run_id = build_run_id(commit, working_tree_dirty)
+
+    train_frame = load_benchmark_part(args.benchmark, "train")
+    valid_frame = load_benchmark_part(args.benchmark, "valid")
+
+    started_at = time.time()
+    validation_predictions = experiment.fit_predict_valid(train_frame, valid_frame, args.benchmark)
+    validate_prediction_contract(validation_predictions)
+
+    experiment_runs_dir = EXPERIMENT_RUNS_DIR
+    experiment_runs_dir.mkdir(parents=True, exist_ok=True)
+    validation_path = experiment_runs_dir / f"{run_id}-{args.benchmark}.csv"
+    validation_predictions.write_csv(validation_path)
+
+    metrics = score_prediction_frame(validation_predictions, args.benchmark)
+    metric_value = float(metrics[METRIC_NAME])
+
+    submission_file = "-"
+    if args.write_submission:
+        submission_file = write_submission(run_id)
+
+    runtime_seconds = time.time() - started_at
+
+    summary = {
+        "run_id": run_id,
+        "commit": commit,
+        "working_tree_dirty": working_tree_dirty,
+        "benchmark": args.benchmark,
+        "approach": experiment.APPROACH,
+        "metric_name": METRIC_NAME,
+        "metric_direction": METRIC_DIRECTION,
+        "metric_value": metric_value,
+        "runtime_seconds": runtime_seconds,
+        "metrics": metrics,
+        "experiment": experiment.DESCRIPTION,
+        "description": description,
+        "validation_predictions": str(validation_path.relative_to(PROJECT_ROOT)),
+        "submission_file": submission_file,
+    }
+    snapshot_dir = archive_run(run_id, summary, validation_path, submission_file)
+    append_result(
+        run_id=run_id,
+        commit=commit,
+        benchmark=args.benchmark,
+        approach=experiment.APPROACH,
+        metric_value=metric_value,
+        runtime_seconds=runtime_seconds,
+        status="ran",
+        description=description,
+        snapshot=str(snapshot_dir.relative_to(PROJECT_ROOT)),
+    )
+
+    print("---")
+    print(f"run_id:                 {run_id}")
+    print(f"benchmark:              {args.benchmark}")
+    print(f"metric_name:            {METRIC_NAME}")
+    print(f"metric_direction:       {METRIC_DIRECTION}")
+    print(f"metric_value:           {metric_value:.6f}")
+    print(f"runtime_seconds:        {runtime_seconds:.1f}")
+    print(f"validation_predictions: {validation_path.relative_to(PROJECT_ROOT)}")
+    print(f"submission_file:        {submission_file}")
+    print(f"experiment:             {experiment.DESCRIPTION}")
+    print(f"description:            {description}")
+    print(f"snapshot:               {snapshot_dir.relative_to(PROJECT_ROOT)}")
+
+
+def validate_prediction_contract(predictions: pl.DataFrame) -> None:
+    if predictions.columns != [ID_COLUMN, TARGET]:
+        raise ValueError(f"Predictions must have columns exactly [{ID_COLUMN}, {TARGET}].")
+
+
+def write_submission(run_id: str) -> str:
+    train_frame = load_train_frame()
+    test_frame = pl.read_csv(DATA_DIR / "test.csv")
+    sample_submission = pl.read_csv(DATA_DIR / "sample_submission.csv")
+    submission = experiment.fit_predict_test(train_frame, test_frame)
+    validate_prediction_contract(submission)
+
+    if not submission[ID_COLUMN].equals(test_frame[ID_COLUMN]):
+        raise ValueError("Submission predictions ids do not match test.csv ids.")
+
+    submission = submission.select(sample_submission.columns)
+    SUBMISSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    output_path = SUBMISSIONS_DIR / f"submission-{run_id}.csv"
+    submission.write_csv(output_path)
+    return str(output_path.relative_to(PROJECT_ROOT))
+
+
+def git_short_commit(project_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "no-git"
+
+    return result.stdout.strip() or "no-git"
+
+
+def git_is_dirty(project_root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--short"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+    return bool(result.stdout.strip())
+
+
+def build_run_id(commit: str, dirty: bool) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    suffix = "dirty" if dirty else commit
+    return f"{timestamp}-{suffix}"
+
+
+def archive_run(run_id: str, summary: dict[str, object], validation_path: Path, submission_file: str) -> Path:
+    run_dir = HISTORY_DIR / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    files_to_copy = [
+        PROJECT_ROOT / "src" / "experiment.py",
+        validation_path,
+        PROJECT_ROOT / "artifacts" / "data_profile.md",
+    ]
+    if submission_file != "-":
+        files_to_copy.append(PROJECT_ROOT / submission_file)
+
+    for path in files_to_copy:
+        if path.exists():
+            shutil.copy2(path, run_dir / path.name)
+
+    summary_path = run_dir / "summary.json"
+    summary_with_snapshot = {**summary, "snapshot": str(run_dir.relative_to(PROJECT_ROOT))}
+    summary_path.write_text(json.dumps(summary_with_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return run_dir
+
+
+def append_result(
+    run_id: str,
+    commit: str,
+    benchmark: str,
+    approach: str,
+    metric_value: float,
+    runtime_seconds: float,
+    status: str,
+    description: str,
+    snapshot: str,
+) -> None:
+    ensure_results_file()
+    row = "\t".join(
+        [
+            run_id,
+            commit,
+            benchmark,
+            approach,
+            METRIC_NAME,
+            METRIC_DIRECTION,
+            f"{metric_value:.6f}",
+            f"{runtime_seconds:.1f}",
+            status,
+            description.replace("\t", " ").strip(),
+            snapshot,
+        ]
+    )
+    with RESULTS_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(f"{row}\n")
+
+
+def ensure_results_file() -> None:
+    if not RESULTS_PATH.exists():
+        RESULTS_PATH.write_text(RESULTS_HEADER, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/Predicting Irrigation Need/src/experiment.py
+++ b/Predicting Irrigation Need/src/experiment.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import polars as pl
-from catboost import CatBoostClassifier, Pool
+from catboost import CatBoostClassifier
+from lightgbm import LGBMClassifier
 from sklearn.metrics import balanced_accuracy_score
 from sklearn.model_selection import StratifiedKFold
 from sklearn.utils.class_weight import compute_class_weight
@@ -14,11 +15,12 @@ from benchmark import ID_COLUMN, TARGET
 
 optuna.logging.set_verbosity(optuna.logging.WARNING)
 
-APPROACH = "xgb_cb_v12"
-DESCRIPTION = "XGB+CB blend, digit features, logit features, bool thresholds, 5-fold OTE, Optuna weight tuning"
+APPROACH = "catboost_v12"
+DESCRIPTION = "3-model ensemble (CB+LGB+XGB), logit+domain+threshold features, 3-fold OTE on top cats, Optuna weight tuning"
 
 RANDOM_SEED = 42
 CPU_THREADS = -1
+N_FOLDS = 3
 
 CATEGORICAL_COLS = [
     "Soil_Type",
@@ -31,7 +33,7 @@ CATEGORICAL_COLS = [
     "Region",
 ]
 
-NUMERICAL_COLS = [
+NUMERIC_COLS = [
     "Soil_pH",
     "Soil_Moisture",
     "Organic_Carbon",
@@ -48,8 +50,23 @@ NUMERICAL_COLS = [
 LABEL_MAP = {"Low": 0, "Medium": 1, "High": 2}
 LABEL_INVERSE = {v: k for k, v in LABEL_MAP.items()}
 
+PAIRWISE_TE_PAIRS = [
+    ("Crop_Type", "Crop_Growth_Stage"),
+    ("Soil_Type", "Region"),
+    ("Crop_Type", "Season"),
+    ("Irrigation_Type", "Water_Source"),
+    ("Crop_Type", "Region"),
+    ("Crop_Growth_Stage", "Season"),
+    ("Soil_Type", "Crop_Type"),
+    ("Crop_Growth_Stage", "Region"),
+    ("Soil_Type", "Crop_Growth_Stage"),
+    ("Season", "Region"),
+    ("Irrigation_Type", "Crop_Type"),
+    ("Mulching_Used", "Crop_Type"),
+]
 
-def add_boolean_thresholds(frame: pl.DataFrame) -> pl.DataFrame:
+
+def add_threshold_features(frame: pl.DataFrame) -> pl.DataFrame:
     return frame.with_columns(
         (pl.col("Soil_Moisture") < 25).cast(pl.Int8).alias("soil_lt_25"),
         (pl.col("Temperature_C") > 30).cast(pl.Int8).alias("temp_gt_30"),
@@ -59,53 +76,51 @@ def add_boolean_thresholds(frame: pl.DataFrame) -> pl.DataFrame:
 
 
 def add_logit_features(frame: pl.DataFrame) -> pl.DataFrame:
-    soil_lt_25 = frame["soil_lt_25"].to_numpy().astype(np.float64)
-    temp_gt_30 = frame["temp_gt_30"].to_numpy().astype(np.float64)
-    rain_lt_300 = frame["rain_lt_300"].to_numpy().astype(np.float64)
-    wind_gt_10 = frame["wind_gt_10"].to_numpy().astype(np.float64)
-    cgs = frame["Crop_Growth_Stage"].to_list()
-    mu = frame["Mulching_Used"].to_list()
-    cgs_flowering = np.array([1.0 if v == "Flowering" else 0.0 for v in cgs])
-    cgs_harvest = np.array([1.0 if v == "Harvest" else 0.0 for v in cgs])
-    cgs_sowing = np.array([1.0 if v == "Sowing" else 0.0 for v in cgs])
-    cgs_vegetative = np.array([1.0 if v == "Vegetative" else 0.0 for v in cgs])
-    mu_no = np.array([1.0 if v == "No" else 0.0 for v in mu])
-    mu_yes = np.array([1.0 if v == "Yes" else 0.0 for v in mu])
-
-    logit_low = (16.3173
-        + (-11.0237 * soil_lt_25) + (-5.8559 * temp_gt_30)
-        + (-10.85 * rain_lt_300) + (-5.8284 * wind_gt_10)
-        + (-5.4155 * cgs_flowering) + (5.5073 * cgs_harvest)
-        + (5.2299 * cgs_sowing) + (-5.4617 * cgs_vegetative)
-        + (-3.0014 * mu_no) + (2.8613 * mu_yes))
-
-    logit_med = (4.6524
-        + (0.329 * soil_lt_25) + (-0.0204 * temp_gt_30)
-        + (0.1542 * rain_lt_300) + (0.0841 * wind_gt_10)
-        + (0.3586 * cgs_flowering) + (-0.1348 * cgs_harvest)
-        + (-0.3547 * cgs_sowing) + (0.3334 * cgs_vegetative)
-        + (0.1883 * mu_no) + (0.0142 * mu_yes))
-
-    logit_high = (-20.9697
-        + (10.6947 * soil_lt_25) + (5.8763 * temp_gt_30)
-        + (10.6958 * rain_lt_300) + (5.7444 * wind_gt_10)
-        + (5.0569 * cgs_flowering) + (-5.3725 * cgs_harvest)
-        + (-4.8752 * cgs_sowing) + (5.1283 * cgs_vegetative)
-        + (2.8131 * mu_no) + (-2.8755 * mu_yes))
+    cgs_flowering = (pl.col("Crop_Growth_Stage") == "Flowering").cast(pl.Int8)
+    cgs_harvest = (pl.col("Crop_Growth_Stage") == "Harvest").cast(pl.Int8)
+    cgs_sowing = (pl.col("Crop_Growth_Stage") == "Sowing").cast(pl.Int8)
+    cgs_vegetative = (pl.col("Crop_Growth_Stage") == "Vegetative").cast(pl.Int8)
+    mulch_no = (pl.col("Mulching_Used") == "No").cast(pl.Int8)
+    mulch_yes = (pl.col("Mulching_Used") == "Yes").cast(pl.Int8)
 
     return frame.with_columns(
-        pl.Series("logit_Low", logit_low, dtype=pl.Float32),
-        pl.Series("logit_Med", logit_med, dtype=pl.Float32),
-        pl.Series("logit_High", logit_high, dtype=pl.Float32),
+        (16.3173
+         + (-11.0237 * pl.col("soil_lt_25"))
+         + (-5.8559 * pl.col("temp_gt_30"))
+         + (-10.85 * pl.col("rain_lt_300"))
+         + (-5.8284 * pl.col("wind_gt_10"))
+         + (-5.4155 * cgs_flowering)
+         + (5.5073 * cgs_harvest)
+         + (5.2299 * cgs_sowing)
+         + (-5.4617 * cgs_vegetative)
+         + (-3.0014 * mulch_no)
+         + (2.8613 * mulch_yes)
+        ).alias("logit_Low"),
+        (4.6524
+         + (0.329 * pl.col("soil_lt_25"))
+         + (-0.0204 * pl.col("temp_gt_30"))
+         + (0.1542 * pl.col("rain_lt_300"))
+         + (0.0841 * pl.col("wind_gt_10"))
+         + (0.3586 * cgs_flowering)
+         + (-0.1348 * cgs_harvest)
+         + (-0.3547 * cgs_sowing)
+         + (0.3334 * cgs_vegetative)
+         + (0.1883 * mulch_no)
+         + (0.0142 * mulch_yes)
+        ).alias("logit_Med"),
+        (-20.9697
+         + (10.6947 * pl.col("soil_lt_25"))
+         + (5.8763 * pl.col("temp_gt_30"))
+         + (10.6958 * pl.col("rain_lt_300"))
+         + (5.7444 * pl.col("wind_gt_10"))
+         + (5.0569 * cgs_flowering)
+         + (-5.3725 * cgs_harvest)
+         + (-4.8752 * cgs_sowing)
+         + (5.1283 * cgs_vegetative)
+         + (2.8131 * mulch_no)
+         + (-2.8755 * mulch_yes)
+        ).alias("logit_High"),
     )
-
-
-def add_digit_features(frame: pl.DataFrame) -> pl.DataFrame:
-    exprs = []
-    for c in NUMERICAL_COLS:
-        for k in range(-4, 4):
-            exprs.append((pl.col(c) // (10**k) % 10).cast(pl.Int8).alias(f"{c}_d{k}"))
-    return frame.with_columns(exprs)
 
 
 def add_domain_features(frame: pl.DataFrame) -> pl.DataFrame:
@@ -135,116 +150,126 @@ def add_domain_features(frame: pl.DataFrame) -> pl.DataFrame:
         np.log1p(pl.col("Soil_Moisture")).alias("Log_moisture"),
         (pl.col("Rainfall_mm") / (pl.col("Field_Area_hectare") + 0.01)).alias("Rain_per_area"),
         (pl.col("Previous_Irrigation_mm") / (pl.col("Field_Area_hectare") + 0.01)).alias("Previrr_per_area"),
-        (pl.col("Soil_pH") * pl.col("Electrical_Conductivity") / (pl.col("Organic_Carbon") + 0.01)).alias("Soil_quality_index"),
         (pl.col("Soil_Moisture") / (pl.col("Rainfall_mm") + pl.col("Previous_Irrigation_mm") + 1.0)).alias("Moisture_per_water_input"),
+        (pl.col("Soil_pH") * pl.col("Electrical_Conductivity") / (pl.col("Organic_Carbon") + 0.01)).alias("Soil_quality"),
+        (pl.col("Soil_Moisture") / (pl.col("Temperature_C") * pl.col("Sunlight_Hours") + 1.0)).alias("Moisture_per_heat_light"),
+        (pl.col("Humidity") * pl.col("Wind_Speed_kmh")).alias("Humid_wind"),
+        (pl.col("Temperature_C") * pl.col("Sunlight_Hours")).alias("Heat_light"),
+        (pl.col("Soil_Moisture") * pl.col("Rainfall_mm")).alias("Moisture_rain"),
+        (pl.col("Humidity") * pl.col("Previous_Irrigation_mm")).alias("Humid_previrr"),
     )
 
 
-class OrderedTE:
-    def __init__(self, a: float = 1.0):
-        self.a = a
-
-    def fit(self, train_df: pd.DataFrame, cat_cols: list[str], target_col: str = TARGET):
-        self.cat_cols = cat_cols
-        self.classes_ = sorted(train_df[target_col].unique())
-        self.global_prior_ = train_df[target_col].value_counts(normalize=True).sort_index().values
-        self.stats_ = {}
-        for c in cat_cols:
-            stats_list = []
-            for k, cls in enumerate(self.classes_):
-                y = (train_df[target_col] == cls).astype(int)
-                grp = train_df[[c]].copy()
-                grp["y"] = y.values
-                cum_cnt = grp.groupby(c, observed=False)["y"].cumcount()
-                cum_sum = grp.groupby(c, observed=False)["y"].cumsum() - grp["y"]
-                prior = self.global_prior_[k]
-                te = (cum_sum + self.a * prior) / (cum_cnt + self.a)
-                train_df[f"{c}_TE_cls{cls}"] = te.values
-                agg = grp.groupby(c, observed=False)["y"].agg(count="count", total="sum").reset_index()
-                agg.columns = [c, f"{c}_n_{cls}", f"{c}_s_{cls}"]
-                stats_list.append(agg)
-            from functools import reduce
-            self.stats_[c] = reduce(lambda l, r: l.merge(r, on=c, how="outer"), stats_list)
-        return train_df
-
-    def transform(self, test_df: pd.DataFrame) -> pd.DataFrame:
-        for c in self.cat_cols:
-            test_df = test_df.merge(self.stats_[c], on=c, how="left")
-            for k, cls in enumerate(self.classes_):
-                n_col, s_col = f"{c}_n_{cls}", f"{c}_s_{cls}"
-                prior = self.global_prior_[k]
-                test_df[f"{c}_TE_cls{cls}"] = (
-                    (test_df[s_col].fillna(0) + self.a * prior) /
-                    (test_df[n_col].fillna(0) + self.a)
-                )
-                test_df.drop([n_col, s_col], axis=1, inplace=True)
-        return test_df
+def compute_target_encoding(train_frame: pl.DataFrame, col: str, smoothing: float = 10.0) -> pl.DataFrame:
+    counts = train_frame.group_by(col).len().rename({"len": "count"})
+    means = train_frame.group_by(col).agg(
+        (pl.col(TARGET) == "High").cast(pl.Int64).mean().alias(f"{col}_te_High"),
+        (pl.col(TARGET) == "Medium").cast(pl.Int64).mean().alias(f"{col}_te_Medium"),
+        (pl.col(TARGET) == "Low").cast(pl.Int64).mean().alias(f"{col}_te_Low"),
+    )
+    global_high = (train_frame[TARGET] == "High").cast(pl.Int64).mean()
+    global_medium = (train_frame[TARGET] == "Medium").cast(pl.Int64).mean()
+    global_low = (train_frame[TARGET] == "Low").cast(pl.Int64).mean()
+    stats = means.join(counts, on=col)
+    return stats.with_columns(
+        ((pl.col("count") * pl.col(f"{col}_te_High") + smoothing * global_high) / (pl.col("count") + smoothing)).alias(f"{col}_te_High"),
+        ((pl.col("count") * pl.col(f"{col}_te_Medium") + smoothing * global_medium) / (pl.col("count") + smoothing)).alias(f"{col}_te_Medium"),
+        ((pl.col("count") * pl.col(f"{col}_te_Low") + smoothing * global_low) / (pl.col("count") + smoothing)).alias(f"{col}_te_Low"),
+    ).select(col, f"{col}_te_High", f"{col}_te_Medium", f"{col}_te_Low")
 
 
-BOOL_FEATS = ["soil_lt_25", "temp_gt_30", "rain_lt_300", "wind_gt_10"]
+def compute_pairwise_target_encoding(train_frame: pl.DataFrame, col1: str, col2: str, smoothing: float = 20.0) -> pl.DataFrame:
+    pair_col = f"{col1}_{col2}"
+    counts = train_frame.group_by([col1, col2]).len().rename({"len": "count"})
+    means = train_frame.group_by([col1, col2]).agg(
+        (pl.col(TARGET) == "High").cast(pl.Int64).mean().alias(f"{pair_col}_te_High"),
+        (pl.col(TARGET) == "Medium").cast(pl.Int64).mean().alias(f"{pair_col}_te_Medium"),
+        (pl.col(TARGET) == "Low").cast(pl.Int64).mean().alias(f"{pair_col}_te_Low"),
+    )
+    global_high = (train_frame[TARGET] == "High").cast(pl.Int64).mean()
+    global_medium = (train_frame[TARGET] == "Medium").cast(pl.Int64).mean()
+    global_low = (train_frame[TARGET] == "Low").cast(pl.Int64).mean()
+    stats = means.join(counts, on=[col1, col2])
+    return stats.with_columns(
+        ((pl.col("count") * pl.col(f"{pair_col}_te_High") + smoothing * global_high) / (pl.col("count") + smoothing)).alias(f"{pair_col}_te_High"),
+        ((pl.col("count") * pl.col(f"{pair_col}_te_Medium") + smoothing * global_medium) / (pl.col("count") + smoothing)).alias(f"{pair_col}_te_Medium"),
+        ((pl.col("count") * pl.col(f"{pair_col}_te_Low") + smoothing * global_low) / (pl.col("count") + smoothing)).alias(f"{pair_col}_te_Low"),
+    ).select(col1, col2, f"{pair_col}_te_High", f"{pair_col}_te_Medium", f"{pair_col}_te_Low")
+
+
+def build_encoding_tables(train_frame: pl.DataFrame) -> dict[str, pl.DataFrame]:
+    tables = {}
+    for col in CATEGORICAL_COLS:
+        tables[col] = compute_target_encoding(train_frame, col)
+    for col1, col2 in PAIRWISE_TE_PAIRS:
+        key = f"{col1}_{col2}"
+        tables[key] = compute_pairwise_target_encoding(train_frame, col1, col2)
+    return tables
+
+
+def add_target_encodings(frame: pl.DataFrame, enc_tables: dict[str, pl.DataFrame]) -> pl.DataFrame:
+    for key, enc_df in enc_tables.items():
+        join_cols = [c for c in enc_df.columns if not c.endswith("_te_High") and not c.endswith("_te_Medium") and not c.endswith("_te_Low")]
+        frame = frame.join(enc_df, on=join_cols, how="left")
+    return frame
+
+
+THRESHOLD_FEATS = ["soil_lt_25", "temp_gt_30", "rain_lt_300", "wind_gt_10"]
 LOGIT_FEATS = ["logit_Low", "logit_Med", "logit_High"]
-DOMAIN_FEATS = ["ET_proxy", "Water_supply", "Water_budget", "Inv_moisture", "Temp_per_moisture",
-                "Wind_per_moisture", "Inv_rainfall", "Heat_wind_per_moisture", "Drought_stress",
-                "Moisture_comfort", "Moisture_rain_ratio", "Temp_humid_ratio", "Humid_temp_ratio",
-                "Temp_moisture_diff", "Heat_light_per_rain", "Dry_wind_index", "Moisture_humid_ratio",
-                "Moisture_previrr_ratio", "Moisture_carbon", "Temp_rain", "Humid_moisture",
-                "Log_rain", "Log_moisture", "Rain_per_area", "Previrr_per_area",
-                "Soil_quality_index", "Moisture_per_water_input"]
+
+DOMAIN_COLS = [
+    "ET_proxy", "Water_supply", "Water_budget", "Inv_moisture", "Temp_per_moisture",
+    "Wind_per_moisture", "Inv_rainfall", "Heat_wind_per_moisture", "Drought_stress",
+    "Moisture_comfort", "Moisture_rain_ratio", "Temp_humid_ratio", "Humid_temp_ratio",
+    "Temp_moisture_diff", "Heat_light_per_rain", "Dry_wind_index", "Moisture_humid_ratio",
+    "Moisture_previrr_ratio", "Moisture_carbon", "Temp_rain", "Humid_moisture",
+    "Log_rain", "Log_moisture", "Rain_per_area", "Previrr_per_area",
+    "Moisture_per_water_input", "Soil_quality", "Moisture_per_heat_light",
+    "Humid_wind", "Heat_light", "Moisture_rain", "Humid_previrr",
+]
 
 
-def _build_features_polars(frame: pl.DataFrame) -> pl.DataFrame:
+def build_feature_frame(frame: pl.DataFrame, enc_tables: dict[str, pl.DataFrame] | None = None) -> tuple[pl.DataFrame, list[str]]:
     features = frame
     for column in (TARGET, ID_COLUMN):
         if column in features.columns:
             features = features.drop(column)
-    features = add_boolean_thresholds(features)
+
+    features = add_threshold_features(features)
     features = add_logit_features(features)
-    features = add_digit_features(features)
     features = add_domain_features(features)
+
+    te_cols = []
+    if enc_tables is not None:
+        features = add_target_encodings(features, enc_tables)
+        for key in enc_tables:
+            te_cols.extend(c for c in features.columns if c.startswith(key) and c.endswith(("_te_High", "_te_Medium", "_te_Low")))
+
     for col in features.columns:
         if features[col].dtype == pl.Float64:
             features = features.with_columns(pl.col(col).cast(pl.Float32))
-    return features
+
+    cat_cols = [c for c in features.columns if not features.schema[c].is_numeric()]
+    return features, cat_cols
 
 
-def _remove_constant_cols(train: pl.DataFrame, test: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame, list[str]]:
-    drop = [c for c in train.columns if train[c].n_unique() <= 1]
-    train = train.drop(drop)
-    test = test.drop(drop)
-    return train, test, drop
-
-
-def _align_columns(train: pl.DataFrame, test: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
-    train_cols = set(train.columns)
-    test_cols = set(test.columns)
-    for c in train_cols - test_cols:
-        test = test.with_columns(pl.lit(0).cast(train[c].dtype).alias(c))
-    for c in test_cols - train_cols:
-        train = train.with_columns(pl.lit(0).cast(test[c].dtype).alias(c))
-    test = test.select(train.columns)
-    return train, test
-
-
-def _get_feature_lists(x_train_pl: pl.DataFrame) -> tuple[list[str], list[str]]:
-    digit_cols = [c for c in x_train_pl.columns if any(c.startswith(n + "_d") for n in NUMERICAL_COLS)]
-    te_cat_cols = CATEGORICAL_COLS + BOOL_FEATS + digit_cols
-    te_feat_names = [f"{c}_TE_cls{cls}" for c in te_cat_cols for cls in ["Low", "Medium", "High"]]
-    use_features = NUMERICAL_COLS + BOOL_FEATS + LOGIT_FEATS + DOMAIN_FEATS + digit_cols + te_feat_names
-    return te_cat_cols, use_features
+def to_pandas(frame: pl.DataFrame) -> pd.DataFrame:
+    return pd.DataFrame(frame.to_dict(as_series=False))
 
 
 def fit_predict_valid(train_frame: pl.DataFrame, valid_frame: pl.DataFrame, benchmark_name: str) -> pl.DataFrame:
     del benchmark_name
 
-    x_train_pl = _build_features_polars(train_frame)
-    x_valid_pl = _build_features_polars(valid_frame)
-    x_train_pl, x_valid_pl, dropped = _remove_constant_cols(x_train_pl, x_valid_pl)
-    x_train_pl, x_valid_pl = _align_columns(x_train_pl, x_valid_pl)
+    enc_tables = build_encoding_tables(train_frame)
 
-    te_cat_cols, use_features = _get_feature_lists(x_train_pl)
+    x_train_pl, cat_cols_train = build_feature_frame(train_frame, enc_tables)
+    x_valid_pl, _ = build_feature_frame(valid_frame, enc_tables)
 
-    x_train_pd = x_train_pl.to_pandas()
-    x_valid_pd = x_valid_pl.to_pandas()
+    use_cols = [c for c in x_train_pl.columns if c in x_valid_pl.columns]
+    cat_cols = [c for c in cat_cols_train if c in use_cols]
+
+    x_train = to_pandas(x_train_pl[use_cols])
+    x_valid = to_pandas(x_valid_pl[use_cols])
     y_train_int = [LABEL_MAP[v] for v in train_frame[TARGET].to_list()]
     y_valid_str = valid_frame[TARGET].to_list()
     y_valid_int = [LABEL_MAP[v] for v in y_valid_str]
@@ -254,32 +279,22 @@ def fit_predict_valid(train_frame: pl.DataFrame, valid_frame: pl.DataFrame, benc
     cw_dict = dict(zip(classes, weights))
     sw = np.array([cw_dict[l] for l in y_train_int])
 
-    oof_cb = np.zeros((len(train_frame), 3))
-    oof_xgb = np.zeros((len(train_frame), 3))
-    pred_cb = np.zeros((len(valid_frame), 3))
-    pred_xgb = np.zeros((len(valid_frame), 3))
+    oof_cb = np.zeros((len(y_train_int), 3))
+    oof_lgb = np.zeros((len(y_train_int), 3))
+    oof_xgb = np.zeros((len(y_train_int), 3))
+    pred_cb = np.zeros((len(y_valid_str), 3))
+    pred_lgb = np.zeros((len(y_valid_str), 3))
+    pred_xgb = np.zeros((len(y_valid_str), 3))
 
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_SEED)
+    kf = StratifiedKFold(n_splits=N_FOLDS, shuffle=True, random_state=RANDOM_SEED)
 
-    for fold, (ti, vi) in enumerate(kf.split(x_train_pd, y_train_int)):
-        print(f"  Fold {fold+1}/5")
-        Xtr = x_train_pd.iloc[ti].reset_index(drop=True).copy()
-        Xv = x_train_pd.iloc[vi].reset_index(drop=True).copy()
-        Xt = x_valid_pd.copy()
+    for fold, (ti, vi) in enumerate(kf.split(x_train, y_train_int)):
+        print(f"  Fold {fold+1}/{N_FOLDS}")
+        Xtr = x_train.iloc[ti].copy()
+        Xv = x_train.iloc[vi].copy()
+        Xt = x_valid.copy()
         ytr = np.array(y_train_int)[ti]
         yv = np.array(y_train_int)[vi]
-
-        Xtr[TARGET] = ytr
-        te = OrderedTE(a=1)
-        Xtr = te.fit(Xtr, cat_cols=te_cat_cols, target_col=TARGET)
-        Xv = te.transform(Xv)
-        Xt = te.transform(Xt)
-        Xtr.drop(TARGET, axis=1, inplace=True)
-
-        avail = [f for f in use_features if f in Xtr.columns]
-        Xtr_f = Xtr[avail].values
-        Xv_f = Xv[avail].values
-        Xt_f = Xt[avail].values
 
         cb = CatBoostClassifier(
             loss_function="MultiClass",
@@ -295,56 +310,82 @@ def fit_predict_valid(train_frame: pl.DataFrame, valid_frame: pl.DataFrame, benc
             od_wait=100,
             l2_leaf_reg=5,
         )
-        cb.fit(Xtr_f, ytr, eval_set=(Xv_f, yv), use_best_model=True)
-        oof_cb[vi] = cb.predict_proba(Xv_f)
-        pred_cb += cb.predict_proba(Xt_f) / 5
+        cb.fit(Xtr, ytr, cat_features=cat_cols, eval_set=(Xv, yv), use_best_model=True)
+        oof_cb[vi] = cb.predict_proba(Xv)
+        pred_cb += cb.predict_proba(Xt) / N_FOLDS
+
+        for c in cat_cols:
+            Xtr[c] = Xtr[c].astype("category")
+            Xv[c] = Xv[c].astype("category")
+            Xt[c] = Xt[c].astype("category")
+
+        import lightgbm
+        lgb = LGBMClassifier(
+            objective="multiclass",
+            num_class=3,
+            class_weight=cw_dict,
+            n_estimators=2000,
+            max_depth=6,
+            learning_rate=0.05,
+            random_seed=RANDOM_SEED,
+            n_jobs=-1,
+            verbose=-1,
+            reg_lambda=5,
+            colsample_bytree=0.7,
+            subsample=0.7,
+        )
+        lgb.fit(Xtr, ytr, eval_set=[(Xv, yv)],
+                callbacks=[lightgbm.early_stopping(100, verbose=False), lightgbm.log_evaluation(0)])
+        oof_lgb[vi] = lgb.predict_proba(Xv)
+        pred_lgb += lgb.predict_proba(Xt) / N_FOLDS
 
         xgb_m = XGBClassifier(
             n_estimators=2000, max_depth=4, max_leaves=30, learning_rate=0.05,
             subsample=0.7, colsample_bytree=0.6, reg_alpha=5, reg_lambda=5,
-            max_bin=10000, tree_method="hist", objective="multi:softprob",
+            max_bin=256, tree_method="hist", objective="multi:softprob",
             num_class=3, eval_metric="mlogloss", random_state=RANDOM_SEED,
             n_jobs=-1, early_stopping_rounds=100, verbosity=0,
         )
-        xgb_m.fit(Xtr_f, ytr, eval_set=[(Xv_f, yv)], sample_weight=sw[ti], verbose=False)
-        oof_xgb[vi] = xgb_m.predict_proba(Xv_f)
-        pred_xgb += xgb_m.predict_proba(Xt_f) / 5
-
-    oof_avg = (oof_cb + oof_xgb) / 2.0
-    cv_before = balanced_accuracy_score(y_train_int, oof_avg.argmax(axis=1))
-    print(f"  OOF BA before tuning: {cv_before:.6f}")
+        xgb_m.fit(Xtr, ytr, eval_set=[(Xv, yv)], sample_weight=sw[ti], verbose=False)
+        oof_xgb[vi] = xgb_m.predict_proba(Xv)
+        pred_xgb += xgb_m.predict_proba(Xt) / N_FOLDS
 
     def objective(trial):
-        w0 = trial.suggest_float("w0", 0.5, 2.0)
-        w1 = trial.suggest_float("w1", 0.5, 2.0)
-        w2 = trial.suggest_float("w2", 0.5, 8.0)
-        adj = oof_avg * np.array([w0, w1, w2])
-        adj = adj / adj.sum(axis=1, keepdims=True)
-        return balanced_accuracy_score(y_train_int, adj.argmax(axis=1))
+        w_cb = trial.suggest_float("w_cb", 0.1, 3.0)
+        w_lgb = trial.suggest_float("w_lgb", 0.1, 3.0)
+        w_xgb = trial.suggest_float("w_xgb", 0.1, 3.0)
+        oof_blend = (w_cb * oof_cb + w_lgb * oof_lgb + w_xgb * oof_xgb)
+        p0 = trial.suggest_float("p0", 0.5, 2.0)
+        p1 = trial.suggest_float("p1", 0.5, 2.0)
+        p2 = trial.suggest_float("p2", 0.5, 2.0)
+        oof_blend = oof_blend * np.array([p0, p1, p2])
+        oof_blend = oof_blend / oof_blend.sum(axis=1, keepdims=True)
+        return balanced_accuracy_score(y_train_int, oof_blend.argmax(axis=1))
 
     study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=300)
-    best_w = np.array([study.best_params["w0"], study.best_params["w1"], study.best_params["w2"]])
-    print(f"  Optuna best weights: {best_w}, OOF BA: {study.best_value:.6f}")
+    study.optimize(objective, n_trials=200)
+    print(f"  Optuna best: {study.best_value:.6f}")
 
-    pred_avg = (pred_cb + pred_xgb) / 2.0
-    adjusted = pred_avg * best_w
-    adjusted = adjusted / adjusted.sum(axis=1, keepdims=True)
-    predictions = [LABEL_INVERSE[i] for i in adjusted.argmax(axis=1)]
+    bp = study.best_params
+    pred_blend = (bp["w_cb"] * pred_cb + bp["w_lgb"] * pred_lgb + bp["w_xgb"] * pred_xgb)
+    pred_blend = pred_blend * np.array([bp["p0"], bp["p1"], bp["p2"]])
+    pred_blend = pred_blend / pred_blend.sum(axis=1, keepdims=True)
+    predictions = [LABEL_INVERSE[i] for i in pred_blend.argmax(axis=1)]
 
     return pl.DataFrame({ID_COLUMN: valid_frame[ID_COLUMN].to_list(), TARGET: predictions})
 
 
 def fit_predict_test(train_frame: pl.DataFrame, test_frame: pl.DataFrame) -> pl.DataFrame:
-    x_train_pl = _build_features_polars(train_frame)
-    x_test_pl = _build_features_polars(test_frame)
-    x_train_pl, x_test_pl, dropped = _remove_constant_cols(x_train_pl, x_test_pl)
-    x_train_pl, x_test_pl = _align_columns(x_train_pl, x_test_pl)
+    enc_tables = build_encoding_tables(train_frame)
 
-    te_cat_cols, use_features = _get_feature_lists(x_train_pl)
+    x_train_pl, cat_cols_train = build_feature_frame(train_frame, enc_tables)
+    x_test_pl, _ = build_feature_frame(test_frame, enc_tables)
 
-    x_train_pd = x_train_pl.to_pandas()
-    x_test_pd = x_test_pl.to_pandas()
+    use_cols = [c for c in x_train_pl.columns if c in x_test_pl.columns]
+    cat_cols = [c for c in cat_cols_train if c in use_cols]
+
+    x_train = to_pandas(x_train_pl[use_cols])
+    x_test = to_pandas(x_test_pl[use_cols])
     y_train_int = [LABEL_MAP[v] for v in train_frame[TARGET].to_list()]
 
     classes = np.unique(y_train_int)
@@ -352,77 +393,57 @@ def fit_predict_test(train_frame: pl.DataFrame, test_frame: pl.DataFrame) -> pl.
     cw_dict = dict(zip(classes, weights))
     sw = np.array([cw_dict[l] for l in y_train_int])
 
-    oof_cb = np.zeros((len(train_frame), 3))
-    oof_xgb = np.zeros((len(train_frame), 3))
-    pred_cb = np.zeros((len(test_frame), 3))
-    pred_xgb = np.zeros((len(test_frame), 3))
+    pred_cb = np.zeros((len(x_test), 3))
+    pred_lgb = np.zeros((len(x_test), 3))
+    pred_xgb = np.zeros((len(x_test), 3))
 
-    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_SEED)
+    cb_final = CatBoostClassifier(
+        loss_function="MultiClass",
+        class_weights=cw_dict,
+        depth=6,
+        learning_rate=0.05,
+        iterations=2000,
+        random_seed=RANDOM_SEED,
+        thread_count=CPU_THREADS,
+        allow_writing_files=False,
+        verbose=False,
+        l2_leaf_reg=5,
+    )
+    cb_final.fit(x_train, y_train_int, cat_features=cat_cols)
+    pred_cb = cb_final.predict_proba(x_test)
 
-    for fold, (ti, vi) in enumerate(kf.split(x_train_pd, y_train_int)):
-        print(f"  Fold {fold+1}/5")
-        Xtr = x_train_pd.iloc[ti].reset_index(drop=True).copy()
-        Xv = x_train_pd.iloc[vi].reset_index(drop=True).copy()
-        Xt = x_test_pd.copy()
-        ytr = np.array(y_train_int)[ti]
-        yv = np.array(y_train_int)[vi]
+    for c in cat_cols:
+        x_train[c] = x_train[c].astype("category")
+        x_test[c] = x_test[c].astype("category")
 
-        Xtr[TARGET] = ytr
-        te = OrderedTE(a=1)
-        Xtr = te.fit(Xtr, cat_cols=te_cat_cols, target_col=TARGET)
-        Xv = te.transform(Xv)
-        Xt = te.transform(Xt)
-        Xtr.drop(TARGET, axis=1, inplace=True)
+    lgb_final = LGBMClassifier(
+        objective="multiclass",
+        num_class=3,
+        class_weight=cw_dict,
+        n_estimators=2000,
+        max_depth=6,
+        learning_rate=0.05,
+        random_seed=RANDOM_SEED,
+        n_jobs=-1,
+        verbose=-1,
+        reg_lambda=5,
+        colsample_bytree=0.7,
+        subsample=0.7,
+    )
+    lgb_final.fit(x_train, y_train_int)
+    pred_lgb = lgb_final.predict_proba(x_test)
 
-        avail = [f for f in use_features if f in Xtr.columns]
-        Xtr_f = Xtr[avail].values
-        Xv_f = Xv[avail].values
-        Xt_f = Xt[avail].values
+    xgb_final = XGBClassifier(
+        n_estimators=2000, max_depth=4, max_leaves=30, learning_rate=0.05,
+        subsample=0.7, colsample_bytree=0.6, reg_alpha=5, reg_lambda=5,
+        max_bin=256, tree_method="hist", objective="multi:softprob",
+        num_class=3, eval_metric="mlogloss", random_state=RANDOM_SEED,
+        n_jobs=-1, verbosity=0,
+    )
+    xgb_final.fit(x_train, y_train_int, sample_weight=sw, verbose=False)
+    pred_xgb = xgb_final.predict_proba(x_test)
 
-        cb = CatBoostClassifier(
-            loss_function="MultiClass",
-            class_weights=cw_dict,
-            depth=6,
-            learning_rate=0.05,
-            iterations=2000,
-            random_seed=RANDOM_SEED,
-            thread_count=CPU_THREADS,
-            allow_writing_files=False,
-            verbose=False,
-            l2_leaf_reg=5,
-        )
-        cb.fit(Xtr_f, ytr, eval_set=(Xv_f, yv), use_best_model=True)
-        oof_cb[vi] = cb.predict_proba(Xv_f)
-        pred_cb += cb.predict_proba(Xt_f) / 5
-
-        xgb_m = XGBClassifier(
-            n_estimators=2000, max_depth=4, max_leaves=30, learning_rate=0.05,
-            subsample=0.7, colsample_bytree=0.6, reg_alpha=5, reg_lambda=5,
-            max_bin=10000, tree_method="hist", objective="multi:softprob",
-            num_class=3, eval_metric="mlogloss", random_state=RANDOM_SEED,
-            n_jobs=-1, early_stopping_rounds=100, verbosity=0,
-        )
-        xgb_m.fit(Xtr_f, ytr, eval_set=[(Xv_f, yv)], sample_weight=sw[ti], verbose=False)
-        oof_xgb[vi] = xgb_m.predict_proba(Xv_f)
-        pred_xgb += xgb_m.predict_proba(Xt_f) / 5
-
-    oof_avg = (oof_cb + oof_xgb) / 2.0
-
-    def objective(trial):
-        w0 = trial.suggest_float("w0", 0.5, 2.0)
-        w1 = trial.suggest_float("w1", 0.5, 2.0)
-        w2 = trial.suggest_float("w2", 0.5, 8.0)
-        adj = oof_avg * np.array([w0, w1, w2])
-        adj = adj / adj.sum(axis=1, keepdims=True)
-        return balanced_accuracy_score(y_train_int, adj.argmax(axis=1))
-
-    study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=300)
-    best_w = np.array([study.best_params["w0"], study.best_params["w1"], study.best_params["w2"]])
-
-    pred_avg = (pred_cb + pred_xgb) / 2.0
-    adjusted = pred_avg * best_w
-    adjusted = adjusted / adjusted.sum(axis=1, keepdims=True)
-    predictions = [LABEL_INVERSE[i] for i in adjusted.argmax(axis=1)]
+    avg = (pred_cb + pred_lgb + pred_xgb) / 3.0
+    predictions = [LABEL_INVERSE[i] for i in avg.argmax(axis=1)]
 
     return pl.DataFrame({ID_COLUMN: test_frame[ID_COLUMN].to_list(), TARGET: predictions})

--- a/Predicting Irrigation Need/src/experiment.py
+++ b/Predicting Irrigation Need/src/experiment.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import polars as pl
+from catboost import CatBoostClassifier, Pool
+from sklearn.metrics import balanced_accuracy_score
+from sklearn.model_selection import StratifiedKFold
+from sklearn.utils.class_weight import compute_class_weight
+from xgboost import XGBClassifier
+import optuna
+
+from benchmark import ID_COLUMN, TARGET
+
+optuna.logging.set_verbosity(optuna.logging.WARNING)
+
+APPROACH = "xgb_cb_v12"
+DESCRIPTION = "XGB+CB blend, digit features, logit features, bool thresholds, 5-fold OTE, Optuna weight tuning"
+
+RANDOM_SEED = 42
+CPU_THREADS = -1
+
+CATEGORICAL_COLS = [
+    "Soil_Type",
+    "Crop_Type",
+    "Crop_Growth_Stage",
+    "Season",
+    "Irrigation_Type",
+    "Water_Source",
+    "Mulching_Used",
+    "Region",
+]
+
+NUMERICAL_COLS = [
+    "Soil_pH",
+    "Soil_Moisture",
+    "Organic_Carbon",
+    "Electrical_Conductivity",
+    "Temperature_C",
+    "Humidity",
+    "Rainfall_mm",
+    "Sunlight_Hours",
+    "Wind_Speed_kmh",
+    "Field_Area_hectare",
+    "Previous_Irrigation_mm",
+]
+
+LABEL_MAP = {"Low": 0, "Medium": 1, "High": 2}
+LABEL_INVERSE = {v: k for k, v in LABEL_MAP.items()}
+
+
+def add_boolean_thresholds(frame: pl.DataFrame) -> pl.DataFrame:
+    return frame.with_columns(
+        (pl.col("Soil_Moisture") < 25).cast(pl.Int8).alias("soil_lt_25"),
+        (pl.col("Temperature_C") > 30).cast(pl.Int8).alias("temp_gt_30"),
+        (pl.col("Rainfall_mm") < 300).cast(pl.Int8).alias("rain_lt_300"),
+        (pl.col("Wind_Speed_kmh") > 10).cast(pl.Int8).alias("wind_gt_10"),
+    )
+
+
+def add_logit_features(frame: pl.DataFrame) -> pl.DataFrame:
+    soil_lt_25 = frame["soil_lt_25"].to_numpy().astype(np.float64)
+    temp_gt_30 = frame["temp_gt_30"].to_numpy().astype(np.float64)
+    rain_lt_300 = frame["rain_lt_300"].to_numpy().astype(np.float64)
+    wind_gt_10 = frame["wind_gt_10"].to_numpy().astype(np.float64)
+    cgs = frame["Crop_Growth_Stage"].to_list()
+    mu = frame["Mulching_Used"].to_list()
+    cgs_flowering = np.array([1.0 if v == "Flowering" else 0.0 for v in cgs])
+    cgs_harvest = np.array([1.0 if v == "Harvest" else 0.0 for v in cgs])
+    cgs_sowing = np.array([1.0 if v == "Sowing" else 0.0 for v in cgs])
+    cgs_vegetative = np.array([1.0 if v == "Vegetative" else 0.0 for v in cgs])
+    mu_no = np.array([1.0 if v == "No" else 0.0 for v in mu])
+    mu_yes = np.array([1.0 if v == "Yes" else 0.0 for v in mu])
+
+    logit_low = (16.3173
+        + (-11.0237 * soil_lt_25) + (-5.8559 * temp_gt_30)
+        + (-10.85 * rain_lt_300) + (-5.8284 * wind_gt_10)
+        + (-5.4155 * cgs_flowering) + (5.5073 * cgs_harvest)
+        + (5.2299 * cgs_sowing) + (-5.4617 * cgs_vegetative)
+        + (-3.0014 * mu_no) + (2.8613 * mu_yes))
+
+    logit_med = (4.6524
+        + (0.329 * soil_lt_25) + (-0.0204 * temp_gt_30)
+        + (0.1542 * rain_lt_300) + (0.0841 * wind_gt_10)
+        + (0.3586 * cgs_flowering) + (-0.1348 * cgs_harvest)
+        + (-0.3547 * cgs_sowing) + (0.3334 * cgs_vegetative)
+        + (0.1883 * mu_no) + (0.0142 * mu_yes))
+
+    logit_high = (-20.9697
+        + (10.6947 * soil_lt_25) + (5.8763 * temp_gt_30)
+        + (10.6958 * rain_lt_300) + (5.7444 * wind_gt_10)
+        + (5.0569 * cgs_flowering) + (-5.3725 * cgs_harvest)
+        + (-4.8752 * cgs_sowing) + (5.1283 * cgs_vegetative)
+        + (2.8131 * mu_no) + (-2.8755 * mu_yes))
+
+    return frame.with_columns(
+        pl.Series("logit_Low", logit_low, dtype=pl.Float32),
+        pl.Series("logit_Med", logit_med, dtype=pl.Float32),
+        pl.Series("logit_High", logit_high, dtype=pl.Float32),
+    )
+
+
+def add_digit_features(frame: pl.DataFrame) -> pl.DataFrame:
+    exprs = []
+    for c in NUMERICAL_COLS:
+        for k in range(-4, 4):
+            exprs.append((pl.col(c) // (10**k) % 10).cast(pl.Int8).alias(f"{c}_d{k}"))
+    return frame.with_columns(exprs)
+
+
+def add_domain_features(frame: pl.DataFrame) -> pl.DataFrame:
+    return frame.with_columns(
+        (pl.col("Temperature_C") * pl.col("Sunlight_Hours")).alias("ET_proxy"),
+        (pl.col("Rainfall_mm") + pl.col("Previous_Irrigation_mm")).alias("Water_supply"),
+        (pl.col("Rainfall_mm") + pl.col("Previous_Irrigation_mm") - pl.col("Temperature_C") * pl.col("Sunlight_Hours")).alias("Water_budget"),
+        (1.0 / (pl.col("Soil_Moisture") + 1.0)).alias("Inv_moisture"),
+        (pl.col("Temperature_C") / (pl.col("Soil_Moisture") + 1.0)).alias("Temp_per_moisture"),
+        (pl.col("Wind_Speed_kmh") / (pl.col("Soil_Moisture") + 1.0)).alias("Wind_per_moisture"),
+        (1.0 / (pl.col("Rainfall_mm") + 1.0)).alias("Inv_rainfall"),
+        (pl.col("Temperature_C") * pl.col("Wind_Speed_kmh") / (pl.col("Soil_Moisture") + 1.0)).alias("Heat_wind_per_moisture"),
+        (pl.col("Temperature_C") * pl.col("Wind_Speed_kmh") * pl.col("Sunlight_Hours") / (pl.col("Soil_Moisture") * pl.col("Humidity") + 1.0)).alias("Drought_stress"),
+        (pl.col("Soil_Moisture") / ((pl.col("Temperature_C") + 1.0) * (pl.col("Wind_Speed_kmh") + 1.0))).alias("Moisture_comfort"),
+        (pl.col("Soil_Moisture") / (pl.col("Rainfall_mm") + 1.0)).alias("Moisture_rain_ratio"),
+        (pl.col("Temperature_C") / (pl.col("Humidity") + 1.0)).alias("Temp_humid_ratio"),
+        (pl.col("Humidity") / (pl.col("Temperature_C") + 1.0)).alias("Humid_temp_ratio"),
+        (pl.col("Temperature_C") - pl.col("Soil_Moisture")).alias("Temp_moisture_diff"),
+        (pl.col("Temperature_C") * pl.col("Sunlight_Hours") / (pl.col("Rainfall_mm") + 1.0)).alias("Heat_light_per_rain"),
+        (pl.col("Wind_Speed_kmh") * pl.col("Temperature_C") / (pl.col("Humidity") + 1.0)).alias("Dry_wind_index"),
+        (pl.col("Soil_Moisture") / (pl.col("Humidity") + 1.0)).alias("Moisture_humid_ratio"),
+        (pl.col("Soil_Moisture") / (pl.col("Previous_Irrigation_mm") + 1.0)).alias("Moisture_previrr_ratio"),
+        (pl.col("Soil_Moisture") * pl.col("Organic_Carbon")).alias("Moisture_carbon"),
+        (pl.col("Temperature_C") * pl.col("Rainfall_mm")).alias("Temp_rain"),
+        (pl.col("Humidity") * pl.col("Soil_Moisture")).alias("Humid_moisture"),
+        np.log1p(pl.col("Rainfall_mm")).alias("Log_rain"),
+        np.log1p(pl.col("Soil_Moisture")).alias("Log_moisture"),
+        (pl.col("Rainfall_mm") / (pl.col("Field_Area_hectare") + 0.01)).alias("Rain_per_area"),
+        (pl.col("Previous_Irrigation_mm") / (pl.col("Field_Area_hectare") + 0.01)).alias("Previrr_per_area"),
+        (pl.col("Soil_pH") * pl.col("Electrical_Conductivity") / (pl.col("Organic_Carbon") + 0.01)).alias("Soil_quality_index"),
+        (pl.col("Soil_Moisture") / (pl.col("Rainfall_mm") + pl.col("Previous_Irrigation_mm") + 1.0)).alias("Moisture_per_water_input"),
+    )
+
+
+class OrderedTE:
+    def __init__(self, a: float = 1.0):
+        self.a = a
+
+    def fit(self, train_df: pd.DataFrame, cat_cols: list[str], target_col: str = TARGET):
+        self.cat_cols = cat_cols
+        self.classes_ = sorted(train_df[target_col].unique())
+        self.global_prior_ = train_df[target_col].value_counts(normalize=True).sort_index().values
+        self.stats_ = {}
+        for c in cat_cols:
+            stats_list = []
+            for k, cls in enumerate(self.classes_):
+                y = (train_df[target_col] == cls).astype(int)
+                grp = train_df[[c]].copy()
+                grp["y"] = y.values
+                cum_cnt = grp.groupby(c, observed=False)["y"].cumcount()
+                cum_sum = grp.groupby(c, observed=False)["y"].cumsum() - grp["y"]
+                prior = self.global_prior_[k]
+                te = (cum_sum + self.a * prior) / (cum_cnt + self.a)
+                train_df[f"{c}_TE_cls{cls}"] = te.values
+                agg = grp.groupby(c, observed=False)["y"].agg(count="count", total="sum").reset_index()
+                agg.columns = [c, f"{c}_n_{cls}", f"{c}_s_{cls}"]
+                stats_list.append(agg)
+            from functools import reduce
+            self.stats_[c] = reduce(lambda l, r: l.merge(r, on=c, how="outer"), stats_list)
+        return train_df
+
+    def transform(self, test_df: pd.DataFrame) -> pd.DataFrame:
+        for c in self.cat_cols:
+            test_df = test_df.merge(self.stats_[c], on=c, how="left")
+            for k, cls in enumerate(self.classes_):
+                n_col, s_col = f"{c}_n_{cls}", f"{c}_s_{cls}"
+                prior = self.global_prior_[k]
+                test_df[f"{c}_TE_cls{cls}"] = (
+                    (test_df[s_col].fillna(0) + self.a * prior) /
+                    (test_df[n_col].fillna(0) + self.a)
+                )
+                test_df.drop([n_col, s_col], axis=1, inplace=True)
+        return test_df
+
+
+BOOL_FEATS = ["soil_lt_25", "temp_gt_30", "rain_lt_300", "wind_gt_10"]
+LOGIT_FEATS = ["logit_Low", "logit_Med", "logit_High"]
+DOMAIN_FEATS = ["ET_proxy", "Water_supply", "Water_budget", "Inv_moisture", "Temp_per_moisture",
+                "Wind_per_moisture", "Inv_rainfall", "Heat_wind_per_moisture", "Drought_stress",
+                "Moisture_comfort", "Moisture_rain_ratio", "Temp_humid_ratio", "Humid_temp_ratio",
+                "Temp_moisture_diff", "Heat_light_per_rain", "Dry_wind_index", "Moisture_humid_ratio",
+                "Moisture_previrr_ratio", "Moisture_carbon", "Temp_rain", "Humid_moisture",
+                "Log_rain", "Log_moisture", "Rain_per_area", "Previrr_per_area",
+                "Soil_quality_index", "Moisture_per_water_input"]
+
+
+def _build_features_polars(frame: pl.DataFrame) -> pl.DataFrame:
+    features = frame
+    for column in (TARGET, ID_COLUMN):
+        if column in features.columns:
+            features = features.drop(column)
+    features = add_boolean_thresholds(features)
+    features = add_logit_features(features)
+    features = add_digit_features(features)
+    features = add_domain_features(features)
+    for col in features.columns:
+        if features[col].dtype == pl.Float64:
+            features = features.with_columns(pl.col(col).cast(pl.Float32))
+    return features
+
+
+def _remove_constant_cols(train: pl.DataFrame, test: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame, list[str]]:
+    drop = [c for c in train.columns if train[c].n_unique() <= 1]
+    train = train.drop(drop)
+    test = test.drop(drop)
+    return train, test, drop
+
+
+def _align_columns(train: pl.DataFrame, test: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
+    train_cols = set(train.columns)
+    test_cols = set(test.columns)
+    for c in train_cols - test_cols:
+        test = test.with_columns(pl.lit(0).cast(train[c].dtype).alias(c))
+    for c in test_cols - train_cols:
+        train = train.with_columns(pl.lit(0).cast(test[c].dtype).alias(c))
+    test = test.select(train.columns)
+    return train, test
+
+
+def _get_feature_lists(x_train_pl: pl.DataFrame) -> tuple[list[str], list[str]]:
+    digit_cols = [c for c in x_train_pl.columns if any(c.startswith(n + "_d") for n in NUMERICAL_COLS)]
+    te_cat_cols = CATEGORICAL_COLS + BOOL_FEATS + digit_cols
+    te_feat_names = [f"{c}_TE_cls{cls}" for c in te_cat_cols for cls in ["Low", "Medium", "High"]]
+    use_features = NUMERICAL_COLS + BOOL_FEATS + LOGIT_FEATS + DOMAIN_FEATS + digit_cols + te_feat_names
+    return te_cat_cols, use_features
+
+
+def fit_predict_valid(train_frame: pl.DataFrame, valid_frame: pl.DataFrame, benchmark_name: str) -> pl.DataFrame:
+    del benchmark_name
+
+    x_train_pl = _build_features_polars(train_frame)
+    x_valid_pl = _build_features_polars(valid_frame)
+    x_train_pl, x_valid_pl, dropped = _remove_constant_cols(x_train_pl, x_valid_pl)
+    x_train_pl, x_valid_pl = _align_columns(x_train_pl, x_valid_pl)
+
+    te_cat_cols, use_features = _get_feature_lists(x_train_pl)
+
+    x_train_pd = x_train_pl.to_pandas()
+    x_valid_pd = x_valid_pl.to_pandas()
+    y_train_int = [LABEL_MAP[v] for v in train_frame[TARGET].to_list()]
+    y_valid_str = valid_frame[TARGET].to_list()
+    y_valid_int = [LABEL_MAP[v] for v in y_valid_str]
+
+    classes = np.unique(y_train_int)
+    weights = compute_class_weight(class_weight="balanced", classes=classes, y=y_train_int)
+    cw_dict = dict(zip(classes, weights))
+    sw = np.array([cw_dict[l] for l in y_train_int])
+
+    oof_cb = np.zeros((len(train_frame), 3))
+    oof_xgb = np.zeros((len(train_frame), 3))
+    pred_cb = np.zeros((len(valid_frame), 3))
+    pred_xgb = np.zeros((len(valid_frame), 3))
+
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_SEED)
+
+    for fold, (ti, vi) in enumerate(kf.split(x_train_pd, y_train_int)):
+        print(f"  Fold {fold+1}/5")
+        Xtr = x_train_pd.iloc[ti].reset_index(drop=True).copy()
+        Xv = x_train_pd.iloc[vi].reset_index(drop=True).copy()
+        Xt = x_valid_pd.copy()
+        ytr = np.array(y_train_int)[ti]
+        yv = np.array(y_train_int)[vi]
+
+        Xtr[TARGET] = ytr
+        te = OrderedTE(a=1)
+        Xtr = te.fit(Xtr, cat_cols=te_cat_cols, target_col=TARGET)
+        Xv = te.transform(Xv)
+        Xt = te.transform(Xt)
+        Xtr.drop(TARGET, axis=1, inplace=True)
+
+        avail = [f for f in use_features if f in Xtr.columns]
+        Xtr_f = Xtr[avail].values
+        Xv_f = Xv[avail].values
+        Xt_f = Xt[avail].values
+
+        cb = CatBoostClassifier(
+            loss_function="MultiClass",
+            class_weights=cw_dict,
+            depth=6,
+            learning_rate=0.05,
+            iterations=2000,
+            random_seed=RANDOM_SEED,
+            thread_count=CPU_THREADS,
+            allow_writing_files=False,
+            verbose=False,
+            od_type="Iter",
+            od_wait=100,
+            l2_leaf_reg=5,
+        )
+        cb.fit(Xtr_f, ytr, eval_set=(Xv_f, yv), use_best_model=True)
+        oof_cb[vi] = cb.predict_proba(Xv_f)
+        pred_cb += cb.predict_proba(Xt_f) / 5
+
+        xgb_m = XGBClassifier(
+            n_estimators=2000, max_depth=4, max_leaves=30, learning_rate=0.05,
+            subsample=0.7, colsample_bytree=0.6, reg_alpha=5, reg_lambda=5,
+            max_bin=10000, tree_method="hist", objective="multi:softprob",
+            num_class=3, eval_metric="mlogloss", random_state=RANDOM_SEED,
+            n_jobs=-1, early_stopping_rounds=100, verbosity=0,
+        )
+        xgb_m.fit(Xtr_f, ytr, eval_set=[(Xv_f, yv)], sample_weight=sw[ti], verbose=False)
+        oof_xgb[vi] = xgb_m.predict_proba(Xv_f)
+        pred_xgb += xgb_m.predict_proba(Xt_f) / 5
+
+    oof_avg = (oof_cb + oof_xgb) / 2.0
+    cv_before = balanced_accuracy_score(y_train_int, oof_avg.argmax(axis=1))
+    print(f"  OOF BA before tuning: {cv_before:.6f}")
+
+    def objective(trial):
+        w0 = trial.suggest_float("w0", 0.5, 2.0)
+        w1 = trial.suggest_float("w1", 0.5, 2.0)
+        w2 = trial.suggest_float("w2", 0.5, 8.0)
+        adj = oof_avg * np.array([w0, w1, w2])
+        adj = adj / adj.sum(axis=1, keepdims=True)
+        return balanced_accuracy_score(y_train_int, adj.argmax(axis=1))
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=300)
+    best_w = np.array([study.best_params["w0"], study.best_params["w1"], study.best_params["w2"]])
+    print(f"  Optuna best weights: {best_w}, OOF BA: {study.best_value:.6f}")
+
+    pred_avg = (pred_cb + pred_xgb) / 2.0
+    adjusted = pred_avg * best_w
+    adjusted = adjusted / adjusted.sum(axis=1, keepdims=True)
+    predictions = [LABEL_INVERSE[i] for i in adjusted.argmax(axis=1)]
+
+    return pl.DataFrame({ID_COLUMN: valid_frame[ID_COLUMN].to_list(), TARGET: predictions})
+
+
+def fit_predict_test(train_frame: pl.DataFrame, test_frame: pl.DataFrame) -> pl.DataFrame:
+    x_train_pl = _build_features_polars(train_frame)
+    x_test_pl = _build_features_polars(test_frame)
+    x_train_pl, x_test_pl, dropped = _remove_constant_cols(x_train_pl, x_test_pl)
+    x_train_pl, x_test_pl = _align_columns(x_train_pl, x_test_pl)
+
+    te_cat_cols, use_features = _get_feature_lists(x_train_pl)
+
+    x_train_pd = x_train_pl.to_pandas()
+    x_test_pd = x_test_pl.to_pandas()
+    y_train_int = [LABEL_MAP[v] for v in train_frame[TARGET].to_list()]
+
+    classes = np.unique(y_train_int)
+    weights = compute_class_weight(class_weight="balanced", classes=classes, y=y_train_int)
+    cw_dict = dict(zip(classes, weights))
+    sw = np.array([cw_dict[l] for l in y_train_int])
+
+    oof_cb = np.zeros((len(train_frame), 3))
+    oof_xgb = np.zeros((len(train_frame), 3))
+    pred_cb = np.zeros((len(test_frame), 3))
+    pred_xgb = np.zeros((len(test_frame), 3))
+
+    kf = StratifiedKFold(n_splits=5, shuffle=True, random_state=RANDOM_SEED)
+
+    for fold, (ti, vi) in enumerate(kf.split(x_train_pd, y_train_int)):
+        print(f"  Fold {fold+1}/5")
+        Xtr = x_train_pd.iloc[ti].reset_index(drop=True).copy()
+        Xv = x_train_pd.iloc[vi].reset_index(drop=True).copy()
+        Xt = x_test_pd.copy()
+        ytr = np.array(y_train_int)[ti]
+        yv = np.array(y_train_int)[vi]
+
+        Xtr[TARGET] = ytr
+        te = OrderedTE(a=1)
+        Xtr = te.fit(Xtr, cat_cols=te_cat_cols, target_col=TARGET)
+        Xv = te.transform(Xv)
+        Xt = te.transform(Xt)
+        Xtr.drop(TARGET, axis=1, inplace=True)
+
+        avail = [f for f in use_features if f in Xtr.columns]
+        Xtr_f = Xtr[avail].values
+        Xv_f = Xv[avail].values
+        Xt_f = Xt[avail].values
+
+        cb = CatBoostClassifier(
+            loss_function="MultiClass",
+            class_weights=cw_dict,
+            depth=6,
+            learning_rate=0.05,
+            iterations=2000,
+            random_seed=RANDOM_SEED,
+            thread_count=CPU_THREADS,
+            allow_writing_files=False,
+            verbose=False,
+            l2_leaf_reg=5,
+        )
+        cb.fit(Xtr_f, ytr, eval_set=(Xv_f, yv), use_best_model=True)
+        oof_cb[vi] = cb.predict_proba(Xv_f)
+        pred_cb += cb.predict_proba(Xt_f) / 5
+
+        xgb_m = XGBClassifier(
+            n_estimators=2000, max_depth=4, max_leaves=30, learning_rate=0.05,
+            subsample=0.7, colsample_bytree=0.6, reg_alpha=5, reg_lambda=5,
+            max_bin=10000, tree_method="hist", objective="multi:softprob",
+            num_class=3, eval_metric="mlogloss", random_state=RANDOM_SEED,
+            n_jobs=-1, early_stopping_rounds=100, verbosity=0,
+        )
+        xgb_m.fit(Xtr_f, ytr, eval_set=[(Xv_f, yv)], sample_weight=sw[ti], verbose=False)
+        oof_xgb[vi] = xgb_m.predict_proba(Xv_f)
+        pred_xgb += xgb_m.predict_proba(Xt_f) / 5
+
+    oof_avg = (oof_cb + oof_xgb) / 2.0
+
+    def objective(trial):
+        w0 = trial.suggest_float("w0", 0.5, 2.0)
+        w1 = trial.suggest_float("w1", 0.5, 2.0)
+        w2 = trial.suggest_float("w2", 0.5, 8.0)
+        adj = oof_avg * np.array([w0, w1, w2])
+        adj = adj / adj.sum(axis=1, keepdims=True)
+        return balanced_accuracy_score(y_train_int, adj.argmax(axis=1))
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=300)
+    best_w = np.array([study.best_params["w0"], study.best_params["w1"], study.best_params["w2"]])
+
+    pred_avg = (pred_cb + pred_xgb) / 2.0
+    adjusted = pred_avg * best_w
+    adjusted = adjusted / adjusted.sum(axis=1, keepdims=True)
+    predictions = [LABEL_INVERSE[i] for i in adjusted.argmax(axis=1)]
+
+    return pl.DataFrame({ID_COLUMN: test_frame[ID_COLUMN].to_list(), TARGET: predictions})

--- a/Predicting Irrigation Need/src/leaderboard.py
+++ b/Predicting Irrigation Need/src/leaderboard.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import polars as pl
+
+from benchmark import PROJECT_ROOT, score_prediction_frame
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Rank benchmark prediction files from the artifacts directory.")
+    parser.add_argument("--benchmark", choices=("smoke", "full"), default="smoke")
+    parser.add_argument(
+        "--glob",
+        default="artifacts/**/*.csv",
+        help="Glob pattern, relative to the competition root, used to find prediction CSVs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    paths = sorted(PROJECT_ROOT.glob(args.glob))
+    if not paths:
+        raise FileNotFoundError(f"No prediction files matched {args.glob!r}")
+
+    rows: list[dict[str, object]] = []
+    for path in paths:
+        try:
+            predictions = pl.read_csv(path)
+            metrics = score_prediction_frame(predictions, args.benchmark)
+        except Exception as exc:
+            rows.append(
+                {
+                    "file": str(path.relative_to(PROJECT_ROOT)),
+                    "status": f"error: {exc}",
+                }
+            )
+            continue
+
+        rows.append(
+            {
+                "file": str(path.relative_to(PROJECT_ROOT)),
+                "status": "ok",
+                **metrics,
+            }
+        )
+
+    leaderboard = pl.DataFrame(rows)
+    if "balanced_accuracy" in leaderboard.columns:
+        leaderboard = leaderboard.with_columns(
+            pl.col("balanced_accuracy").round(6),
+            pl.col("recall_low").round(6),
+            pl.col("recall_medium").round(6),
+            pl.col("recall_high").round(6),
+        ).sort(["status", "balanced_accuracy"], descending=[False, True], nulls_last=True)
+
+    print(leaderboard)
+
+
+if __name__ == "__main__":
+    main()

--- a/Predicting Irrigation Need/src/profile_data.py
+++ b/Predicting Irrigation Need/src/profile_data.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+from benchmark import (
+    BENCHMARK_NAMES,
+    ID_COLUMN,
+    PROJECT_ROOT,
+    TARGET,
+    benchmark_split_column,
+    ensure_benchmark_exists,
+    load_spec,
+    load_split_frame,
+)
+
+
+def main() -> None:
+    data_dir = PROJECT_ROOT / "data"
+    artifact_dir = PROJECT_ROOT / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    train_df = pl.read_csv(data_dir / "train.csv")
+    test_df = pl.read_csv(data_dir / "test.csv")
+    sample_submission = pl.read_csv(data_dir / "sample_submission.csv")
+
+    numeric_features = [name for name, dtype in train_df.schema.items() if dtype.is_numeric() and name not in {ID_COLUMN}]
+    categorical_features = [name for name, dtype in train_df.schema.items() if not dtype.is_numeric() and name != TARGET]
+
+    lines = [
+        "# Data Profile",
+        "",
+        "## Files",
+        "",
+        f"- `train.csv`: {train_df.height} rows x {train_df.width} columns",
+        f"- `test.csv`: {test_df.height} rows x {test_df.width} columns",
+        f"- `sample_submission.csv`: {sample_submission.height} rows x {sample_submission.width} columns",
+        "",
+        "## Roles",
+        "",
+        f"- id column: `{ID_COLUMN}`",
+        f"- target column: `{TARGET}`",
+        f"- numeric features: {len(numeric_features)}",
+        f"- categorical features: {len(categorical_features)}",
+        "",
+        "## Data Quality",
+        "",
+        f"- train duplicate rows: {int(train_df.is_duplicated().sum())}",
+        f"- test duplicate rows: {int(test_df.is_duplicated().sum())}",
+        f"- `{ID_COLUMN}` unique in train: {train_df[ID_COLUMN].n_unique() == train_df.height}",
+        f"- `{ID_COLUMN}` unique in test: {test_df[ID_COLUMN].n_unique() == test_df.height}",
+        f"- sample submission ids match test ids: {sample_submission[ID_COLUMN].equals(test_df[ID_COLUMN])}",
+        f"- null counts in train: {format_counts(nonzero_null_counts(train_df))}",
+        f"- null counts in test: {format_counts(nonzero_null_counts(test_df))}",
+        "",
+        "## Target Distribution",
+        "",
+    ]
+
+    target_distribution = (
+        train_df.group_by(TARGET)
+        .len()
+        .rename({"len": "count"})
+        .with_columns((pl.col("count") / pl.col("count").sum()).alias("share"))
+        .sort(TARGET)
+    )
+    for row in target_distribution.iter_rows(named=True):
+        lines.append(f"- `{row[TARGET]}`: {row['count']} rows ({row['share']:.2%})")
+    lines.append("")
+
+    lines.extend(["## Train/Test Column Checks", ""])
+    train_only = sorted(set(train_df.columns) - set(test_df.columns))
+    test_only = sorted(set(test_df.columns) - set(train_df.columns))
+    lines.append(f"- columns only in train: {format_list(train_only)}")
+    lines.append(f"- columns only in test: {format_list(test_only)}")
+    lines.append("")
+
+    lines.extend(["## Categorical Overlap", ""])
+    for feature in categorical_features:
+        train_levels = set(train_df[feature].drop_nulls().unique().to_list())
+        test_levels = set(test_df[feature].drop_nulls().unique().to_list())
+        lines.append(
+            f"- `{feature}`: train_only={format_list(sorted(train_levels - test_levels))} | "
+            f"test_only={format_list(sorted(test_levels - train_levels))}"
+        )
+    lines.append("")
+
+    lines.extend(["## Numeric Summary", "", "| feature | mean | std | min | max |", "| --- | ---: | ---: | ---: | ---: |"])
+    for feature in numeric_features:
+        if feature == TARGET:
+            continue
+        column = train_df[feature]
+        lines.append(
+            f"| `{feature}` | {float(column.mean()):.6f} | {float(column.std()):.6f} | {float(column.min()):.6f} | {float(column.max()):.6f} |"
+        )
+    lines.append("")
+
+    ensure_benchmark_exists()
+    spec = load_spec()
+    split_frame = load_split_frame()
+    lines.extend(["## Fixed Benchmark", "", f"- version: `{spec['version']}`", f"- metric: `{spec['metric']}`", ""])
+    for benchmark_name in BENCHMARK_NAMES:
+        split_column = benchmark_split_column(benchmark_name)
+        lines.append(f"### {benchmark_name}")
+        lines.append("")
+        for part in ("train", "valid"):
+            part_ids = split_frame.filter(pl.col(split_column) == part).select(ID_COLUMN)
+            part_frame = train_df.join(part_ids, on=ID_COLUMN, how="inner")
+            target_shares = (
+                part_frame.group_by(TARGET)
+                .len()
+                .rename({"len": "count"})
+                .with_columns((pl.col("count") / pl.col("count").sum()).alias("share"))
+                .sort(TARGET)
+            )
+            share_map = {row[TARGET]: row["share"] for row in target_shares.iter_rows(named=True)}
+            lines.append(
+                f"- `{part}`: {part_frame.height} rows | "
+                f"Low={share_map.get('Low', 0.0):.2%}, Medium={share_map.get('Medium', 0.0):.2%}, High={share_map.get('High', 0.0):.2%}"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Modeling Constraints",
+            "",
+            "- Optimize balanced accuracy, not plain accuracy.",
+            "- Respect the fixed benchmark split in `benchmark/holdout_v1/` for comparable local evaluations.",
+            "- Use as many CPU cores as possible whenever the training library supports it.",
+            "- Use `smoke` for quick iteration and `full` to confirm promising changes.",
+            "- If iteration is too slow on the full data, test on `smoke` or another smaller stratified subset first.",
+            "- `data/sample_submission.csv` remains the source of truth for Kaggle submission columns and order.",
+            "",
+        ]
+    )
+
+    output_path = artifact_dir / "data_profile.md"
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+    print(f"Wrote {output_path.relative_to(PROJECT_ROOT)}")
+
+
+def nonzero_null_counts(frame: pl.DataFrame) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for column in frame.columns:
+        null_count = int(frame[column].null_count())
+        if null_count:
+            counts[column] = null_count
+    return counts
+
+
+def format_counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "none"
+    return ", ".join(f"`{column}`={count}" for column, count in counts.items())
+
+
+def format_list(values: list[str]) -> str:
+    if not values:
+        return "-"
+    return ", ".join(f"`{value}`" for value in values)
+
+
+if __name__ == "__main__":
+    main()

--- a/Predicting Irrigation Need/submissions/README.md
+++ b/Predicting Irrigation Need/submissions/README.md
@@ -1,0 +1,3 @@
+# Submissions
+
+Write generated Kaggle submission files here.

--- a/Predicting Irrigation Need/uv.lock
+++ b/Predicting Irrigation Need/uv.lock
@@ -1,0 +1,1445 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "catboost"
+version = "1.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphviz" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "pandas" },
+    { name = "plotly" },
+    { name = "scipy" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/0e/09e8fa0858570fda88090bc3f441b69c18ea3d6f4a02fd41aa5426c157bf/catboost-1.2.10.tar.gz", hash = "sha256:26ae6d423acaf0e9d8160f2477a990431057ed04522d993c2f42dac62743b4f7", size = 39925863, upload-time = "2026-02-18T16:13:29.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/02/3c5f08a7c7969eaa2509d804461db26752fe1c7ecb8ad8510cab51a95fd2/catboost-1.2.10-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:bd3d3b344894f61b5f70124658f302148bb9a51c41d0d5b6c453a72e9dfefc49", size = 28829400, upload-time = "2026-02-18T16:12:23.682Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/63be2ff7aa9f6a7d63e342f42948259a028bfa50203d5ff687c84804ffb7/catboost-1.2.10-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:59aa166f075f0a5ea57b0ba46e5060bd6a22e849e91e4142f16c2df11295b184", size = 96680675, upload-time = "2026-02-18T16:12:28.407Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2c/fa0479bd79226f037b495a30696b70741beb198f65227c975005e213aa8e/catboost-1.2.10-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:42c1b6c7ae5c18cdbe00c8b9493987cc13338fe328baaf1a0b98ddaf58db96a2", size = 97111368, upload-time = "2026-02-18T16:12:32.456Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/a9e9a06418832fbea9d7cefda585d53395358d498537b6bdd3cf7364cd29/catboost-1.2.10-cp313-cp313-win_amd64.whl", hash = "sha256:5ede858e634d6d0f521bf6dd6fad9374f23d37049ee48e0779ccd2a372632cb1", size = 100201430, upload-time = "2026-02-18T16:12:36.731Z" },
+    { url = "https://files.pythonhosted.org/packages/56/58/f370f6c64db5e7da92e3b88ab62e2df72f113cf5a1eee35b48f69d54accd/catboost-1.2.10-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:3efc5e4d414b7c13bff6dd0d6c938cf09bb1445097283c7790e54b8ee461820b", size = 28840256, upload-time = "2026-02-18T16:12:40.153Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/74/18597f0b2923e3660cd44f942fe9e7cddaa99afc252bc745c48f79566330/catboost-1.2.10-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:bad9a70890cdc591080a908d54a3cd70002ab1e48b2017adff84726da0b3e16d", size = 96688527, upload-time = "2026-02-18T16:12:43.534Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ac/7effae0e47fd9586e46a796f5af61b730c572570cedee333ee9ba8db85a8/catboost-1.2.10-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:7b8cc4ea3a6ac4a8d05f3a79c8ee5454360a0a710fa12444963865ad3f0ddfec", size = 97119495, upload-time = "2026-02-18T16:12:47.557Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b7/8f9e284a9cdd034f01f017dc5dab0da03dc3eac171a2be205745da3becb6/catboost-1.2.10-cp314-cp314-win_amd64.whl", hash = "sha256:951c5bdf27b8edb6ca624f41134888c666ae68275488803d3c91ce83e154f0c5", size = 101749687, upload-time = "2026-02-18T16:12:51.736Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/61/f083b5ac52e505dfc1c624eafbf8c7589a0d7f32daa398d2e7590efa5fda/colorlog-6.10.1.tar.gz", hash = "sha256:eb4ae5cb65fe7fec7773c2306061a8e63e02efc2c72eba9d27b0fa23c94f1321", size = 17162, upload-time = "2025-10-16T16:14:11.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl", hash = "sha256:2d7e8348291948af66122cff006c9f8da6255d224e7cf8e37d8de2df3bad8c9c", size = 11743, upload-time = "2025-10-16T16:14:10.512Z" },
+]
+
+[[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
+    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/fa/6d96a0978d19e17b68d634497769987b16c8f4cd0a7a05048bec693caa6b/decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360", size = 56711, upload-time = "2025-02-24T04:41:34.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a", size = 9190, upload-time = "2025-02-24T04:41:32.565Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/56/6f389de21c49555553d6a5aeed5ac9767631497ac836c4f076273d15bd72/fonttools-4.62.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c22b1014017111c401469e3acc5433e6acf6ebcc6aa9efb538a533c800971c79", size = 2865155, upload-time = "2026-03-13T13:53:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c5/0e3966edd5ec668d41dfe418787726752bc07e2f5fd8c8f208615e61fa89/fonttools-4.62.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68959f5fc58ed4599b44aad161c2837477d7f35f5f79402d97439974faebfebe", size = 2412802, upload-time = "2026-03-13T13:53:18.878Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/e6ac4b44026de7786fe46e3bfa0c87e51d5d70a841054065d49cd62bb909/fonttools-4.62.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef46db46c9447103b8f3ff91e8ba009d5fe181b1920a83757a5762551e32bb68", size = 5013926, upload-time = "2026-03-13T13:53:21.379Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/8b1e801939839d405f1f122e7d175cebe9aeb4e114f95bfc45e3152af9a7/fonttools-4.62.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6706d1cb1d5e6251a97ad3c1b9347505c5615c112e66047abbef0f8545fa30d1", size = 4964575, upload-time = "2026-03-13T13:53:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/46/76/7d051671e938b1881670528fec69cc4044315edd71a229c7fd712eaa5119/fonttools-4.62.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2e7abd2b1e11736f58c1de27819e1955a53267c21732e78243fa2fa2e5c1e069", size = 4953693, upload-time = "2026-03-13T13:53:26.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ae/b41f8628ec0be3c1b934fc12b84f4576a5c646119db4d3bdd76a217c90b5/fonttools-4.62.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:403d28ce06ebfc547fbcb0cb8b7f7cc2f7a2d3e1a67ba9a34b14632df9e080f9", size = 5094920, upload-time = "2026-03-13T13:53:29.329Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/53a1e9469331a23dcc400970a27a4caa3d9f6edbf5baab0260285238b884/fonttools-4.62.1-cp313-cp313-win32.whl", hash = "sha256:93c316e0f5301b2adbe6a5f658634307c096fd5aae60a5b3412e4f3e1728ab24", size = 2279928, upload-time = "2026-03-13T13:53:32.352Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/35186529de1db3c01f5ad625bde07c1f576305eab6d86bbda4c58445f721/fonttools-4.62.1-cp313-cp313-win_amd64.whl", hash = "sha256:7aa21ff53e28a9c2157acbc44e5b401149d3c9178107130e82d74ceb500e5056", size = 2330514, upload-time = "2026-03-13T13:53:34.991Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f0/2888cdac391807d68d90dcb16ef858ddc1b5309bfc6966195a459dd326e2/fonttools-4.62.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fa1d16210b6b10a826d71bed68dd9ec24a9e218d5a5e2797f37c573e7ec215ca", size = 2864442, upload-time = "2026-03-13T13:53:37.509Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/b2/e521803081f8dc35990816b82da6360fa668a21b44da4b53fc9e77efcd62/fonttools-4.62.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aa69d10ed420d8121118e628ad47d86e4caa79ba37f968597b958f6cceab7eca", size = 2410901, upload-time = "2026-03-13T13:53:40.55Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/8c3511ff06e53110039358dbbdc1a65d72157a054638387aa2ada300a8b8/fonttools-4.62.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd13b7999d59c5eb1c2b442eb2d0c427cb517a0b7a1f5798fc5c9e003f5ff782", size = 4999608, upload-time = "2026-03-13T13:53:42.798Z" },
+    { url = "https://files.pythonhosted.org/packages/28/63/cd0c3b26afe60995a5295f37c246a93d454023726c3261cfbb3559969bb9/fonttools-4.62.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d337fdd49a79b0d51c4da87bc38169d21c3abbf0c1aa9367eff5c6656fb6dae", size = 4912726, upload-time = "2026-03-13T13:53:45.405Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b9/ac677cb07c24c685cf34f64e140617d58789d67a3dd524164b63648c6114/fonttools-4.62.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d241cdc4a67b5431c6d7f115fdf63335222414995e3a1df1a41e1182acd4bcc7", size = 4951422, upload-time = "2026-03-13T13:53:48.326Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/10/11c08419a14b85b7ca9a9faca321accccc8842dd9e0b1c8a72908de05945/fonttools-4.62.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c05557a78f8fa514da0f869556eeda40887a8abc77c76ee3f74cf241778afd5a", size = 5060979, upload-time = "2026-03-13T13:53:51.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3c/12eea4a4cf054e7ab058ed5ceada43b46809fce2bf319017c4d63ae55bb4/fonttools-4.62.1-cp314-cp314-win32.whl", hash = "sha256:49a445d2f544ce4a69338694cad575ba97b9a75fff02720da0882d1a73f12800", size = 2283733, upload-time = "2026-03-13T13:53:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/67/74b070029043186b5dd13462c958cb7c7f811be0d2e634309d9a1ffb1505/fonttools-4.62.1-cp314-cp314-win_amd64.whl", hash = "sha256:1eecc128c86c552fb963fe846ca4e011b1be053728f798185a1687502f6d398e", size = 2335663, upload-time = "2026-03-13T13:53:56.23Z" },
+    { url = "https://files.pythonhosted.org/packages/42/c5/4d2ed3ca6e33617fc5624467da353337f06e7f637707478903c785bd8e20/fonttools-4.62.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:1596aeaddf7f78e21e68293c011316a25267b3effdaccaf4d59bc9159d681b82", size = 2947288, upload-time = "2026-03-13T13:53:59.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e9/7ab11ddfda48ed0f89b13380e5595ba572619c27077be0b2c447a63ff351/fonttools-4.62.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:8f8fca95d3bb3208f59626a4b0ea6e526ee51f5a8ad5d91821c165903e8d9260", size = 2449023, upload-time = "2026-03-13T13:54:01.642Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/10/a800fa090b5e8819942e54e19b55fc7c21fe14a08757c3aa3ca8db358939/fonttools-4.62.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee91628c08e76f77b533d65feb3fbe6d9dad699f95be51cf0d022db94089cdc4", size = 5137599, upload-time = "2026-03-13T13:54:04.495Z" },
+    { url = "https://files.pythonhosted.org/packages/37/dc/8ccd45033fffd74deb6912fa1ca524643f584b94c87a16036855b498a1ed/fonttools-4.62.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f37df1cac61d906e7b836abe356bc2f34c99d4477467755c216b72aa3dc748b", size = 4920933, upload-time = "2026-03-13T13:54:07.557Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/e618adefb839598d25ac8136cd577925d6c513dc0d931d93b8af956210f0/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92bb00a947e666169c99b43753c4305fc95a890a60ef3aeb2a6963e07902cc87", size = 5016232, upload-time = "2026-03-13T13:54:10.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5f/9b5c9bfaa8ec82def8d8168c4f13615990d6ce5996fe52bd49bfb5e05134/fonttools-4.62.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:bdfe592802ef939a0e33106ea4a318eeb17822c7ee168c290273cbd5fabd746c", size = 5042987, upload-time = "2026-03-13T13:54:13.569Z" },
+    { url = "https://files.pythonhosted.org/packages/90/aa/dfbbe24c6a6afc5c203d90cc0343e24bcbb09e76d67c4d6eef8c2558d7ba/fonttools-4.62.1-cp314-cp314t-win32.whl", hash = "sha256:b820fcb92d4655513d8402d5b219f94481c4443d825b4372c75a2072aa4b357a", size = 2348021, upload-time = "2026-03-13T13:54:16.98Z" },
+    { url = "https://files.pythonhosted.org/packages/13/6f/ae9c4e4dd417948407b680855c2c7790efb52add6009aaecff1e3bc50e8e/fonttools-4.62.1-cp314-cp314t-win_amd64.whl", hash = "sha256:59b372b4f0e113d3746b88985f1c796e7bf830dd54b28374cd85c2b8acd7583e", size = 2414147, upload-time = "2026-03-13T13:54:19.416Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[[package]]
+name = "graphviz"
+version = "0.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b3/3ac91e9be6b761a4b30d66ff165e54439dcd48b83f4e20d644867215f6ca/graphviz-0.21.tar.gz", hash = "sha256:20743e7183be82aaaa8ad6c93f8893c923bd6658a04c32ee115edb3c8a835f78", size = 200434, upload-time = "2025-06-15T09:35:05.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/4c/e0ce1ef95d4000ebc1c11801f9b944fa5910ecc15b5e351865763d8657f8/graphviz-0.21-py3-none-any.whl", hash = "sha256:54f33de9f4f911d7e84e4191749cac8cc5653f815b06738c54db9a15ab8b1e42", size = 47300, upload-time = "2025-06-15T09:35:04.433Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
+name = "ipykernel"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/8d/b68b728e2d06b9e0051019640a40a9eb7a88fcd82c2e1b5ce70bef5ff044/ipykernel-7.2.0.tar.gz", hash = "sha256:18ed160b6dee2cbb16e5f3575858bc19d8f1fe6046a9a680c708494ce31d909e", size = 176046, upload-time = "2026-02-06T16:43:27.403Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/b9/e73d5d9f405cba7706c539aa8b311b49d4c2f3d698d9c12f815231169c71/ipykernel-7.2.0-py3-none-any.whl", hash = "sha256:3bbd4420d2b3cc105cbdf3756bfc04500b1e52f090a90716851f3916c62e1661", size = 118788, upload-time = "2026-02-06T16:43:25.149Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz", hash = "sha256:4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0", size = 1231287, upload-time = "2024-11-11T01:41:42.873Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl", hash = "sha256:a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9", size = 1572278, upload-time = "2024-11-11T01:41:40.175Z" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "kaggle"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "catboost" },
+    { name = "ipykernel" },
+    { name = "lightgbm" },
+    { name = "matplotlib" },
+    { name = "numba" },
+    { name = "optuna" },
+    { name = "pandas" },
+    { name = "polars" },
+    { name = "pyarrow" },
+    { name = "scikit-learn" },
+    { name = "xgboost" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "catboost", specifier = ">=1.2.10" },
+    { name = "ipykernel", specifier = ">=7.2.0" },
+    { name = "lightgbm", specifier = ">=4.6.0" },
+    { name = "matplotlib", specifier = ">=3.10.9" },
+    { name = "numba", specifier = ">=0.61.0" },
+    { name = "optuna", specifier = ">=4.8.0" },
+    { name = "pandas", specifier = ">=3.0.2" },
+    { name = "polars", specifier = ">=1.40.1" },
+    { name = "pyarrow", specifier = ">=24.0.0" },
+    { name = "scikit-learn", specifier = ">=1.8.0" },
+    { name = "xgboost", specifier = ">=3.2.0" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
+name = "lightgbm"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/0b/a2e9f5c5da7ef047cc60cef37f86185088845e8433e54d2e7ed439cce8a3/lightgbm-4.6.0.tar.gz", hash = "sha256:cb1c59720eb569389c0ba74d14f52351b573af489f230032a1c9f314f8bab7fe", size = 1703705, upload-time = "2025-02-15T04:03:03.111Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/75/cffc9962cca296bc5536896b7e65b4a7cdeb8db208e71b9c0133c08f8f7e/lightgbm-4.6.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:b7a393de8a334d5c8e490df91270f0763f83f959574d504c7ccb9eee4aef70ed", size = 2010151, upload-time = "2025-02-15T04:02:50.961Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/550ee378512b78847930f5d74228ca1fdba2a7fbdeaac9aeccc085b0e257/lightgbm-4.6.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:2dafd98d4e02b844ceb0b61450a660681076b1ea6c7adb8c566dfd66832aafad", size = 1592172, upload-time = "2025-02-15T04:02:53.937Z" },
+    { url = "https://files.pythonhosted.org/packages/64/41/4fbde2c3d29e25ee7c41d87df2f2e5eda65b431ee154d4d462c31041846c/lightgbm-4.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4d68712bbd2b57a0b14390cbf9376c1d5ed773fa2e71e099cac588703b590336", size = 3454567, upload-time = "2025-02-15T04:02:56.443Z" },
+    { url = "https://files.pythonhosted.org/packages/42/86/dabda8fbcb1b00bcfb0003c3776e8ade1aa7b413dff0a2c08f457dace22f/lightgbm-4.6.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cb19b5afea55b5b61cbb2131095f50538bd608a00655f23ad5d25ae3e3bf1c8d", size = 3569831, upload-time = "2025-02-15T04:02:58.925Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/23/f8b28ca248bb629b9e08f877dd2965d1994e1674a03d67cd10c5246da248/lightgbm-4.6.0-py3-none-win_amd64.whl", hash = "sha256:37089ee95664b6550a7189d887dbf098e3eadab03537e411f52c63c121e3ba4b", size = 1451509, upload-time = "2025-02-15T04:03:01.515Z" },
+]
+
+[[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/d3/8d4f6afbecb49fc04e060a57c0fce39ea51cc163a6bd87303ccd698e4fa6/matplotlib-3.10.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b580440f1ff81a0e34122051a3dfabb7e4b7f9e380629929bde0eff9af72165f", size = 8320331, upload-time = "2026-04-24T00:12:39.688Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/9e14bc7564bf92d5ffa801ae5fac819ce74b925dfb55e3ebde61a3bbad3e/matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e", size = 8216461, upload-time = "2026-04-24T00:12:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/4402d0d14ccf1dfc70932600b68097fbbf9c898a4871d2cbbe79c7801a32/matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f", size = 8790091, upload-time = "2026-04-24T00:12:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0b/322aeec06dd9b91411f92028b37d447342770a24392aa4813e317064dad5/matplotlib-3.10.9-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a8d66a55def891c33147ba3ba9bfcabf0b526a43764c818acbb4525e5ed0838", size = 9605027, upload-time = "2026-04-24T00:12:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/74/88/5f13482f55e7b00bcfc09838b093c2456e1379978d2a146844aae05350ad/matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2", size = 9671269, upload-time = "2026-04-24T00:12:50.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/0840fd2f93da988ec660b8ad1984abe9f25d2aed22a5e394ff1c68c88307/matplotlib-3.10.9-cp313-cp313-win_amd64.whl", hash = "sha256:f4399f64b3e94cd500195490972ae1ee81170df1636fa15364d157d5bdd7b921", size = 8217588, upload-time = "2026-04-24T00:12:53.784Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b9/d706d06dd605c49b9f83a2aed8c13e3e5db70697d7a80b7e3d7915de6b17/matplotlib-3.10.9-cp313-cp313-win_arm64.whl", hash = "sha256:ba7b3b8ef09eab7df0e86e9ae086faa433efbfbdb46afcb3aa16aabf779469a8", size = 8136913, upload-time = "2026-04-24T00:12:56.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/6e32d96978264c8ca8c4b1010adb955a1a49cfaf314e212bbc8908f04a61/matplotlib-3.10.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:09218df8a93712bd6ea133e83a153c755448cf7868316c531cffcc43f69d1cc9", size = 8368019, upload-time = "2026-04-24T00:12:58.896Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0a/c8e3d3bba245f0f7fc424937f8ff7ef77291a36af3edb97ccd78aa93d84f/matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4", size = 8264645, upload-time = "2026-04-24T00:13:01.406Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/5bf5a14fe4fed73a4209a155606f8096ff797aad89c6c35179026571133e/matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc", size = 8802194, upload-time = "2026-04-24T00:13:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/b4be852d6bba6fd15893fadf91ff26ae49cb91aac789e95dde9d342e664f/matplotlib-3.10.9-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de2445a0c6690d21b7eb6ce071cebad6d40a2e9bdf10d039074a96ba19797b99", size = 9622684, upload-time = "2026-04-24T00:13:06.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/ed428c971139112ef730f62770654d609467346d09d4b62617e1afd68a5a/matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d", size = 9680790, upload-time = "2026-04-24T00:13:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/09/052e884aaf2b985c63cb79f715f1d5b6a3eaa7de78f6a52b9dbc077d5b53/matplotlib-3.10.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9fae004b941b23ff2edcf1567a857ed77bafc8086ffa258190462328434faf8", size = 8287571, upload-time = "2026-04-24T00:13:13.087Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/38/ae27288e788c35a4250491422f3db7750366fc8c97d6f36fbdecfc1f5518/matplotlib-3.10.9-cp313-cp313t-win_arm64.whl", hash = "sha256:6b63d9c7c769b88ab81e10dc86e4e0607cf56817b9f9e6cf24b2a5f1693b8e38", size = 8188292, upload-time = "2026-04-24T00:13:15.546Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e6/3bd8afd04949f02eabc1c17115ea5255e19cacd4d06fc5abdde4eeb0052c/matplotlib-3.10.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:172db52c9e683f5d12eaf57f0f54834190e12581fe1cc2a19595a8f5acb4e77d", size = 8321276, upload-time = "2026-04-24T00:13:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/41/86/86231232fff41c9f8e4a1a7d7a597d349a02527109c3af7d618366122139/matplotlib-3.10.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97e35e8d39ccc85859095e01a53847432ba9a53ddf7986f7a54a11b73d0e143f", size = 8218218, upload-time = "2026-04-24T00:13:20.974Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8f/becc9722cafc64f5d2eb0b7c1bf5f585271c618a45dbd8fabeb021f898b6/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aba1615dabe83188e19d4f75a253c6a08423e04c1425e64039f800050a69de6b", size = 9608145, upload-time = "2026-04-24T00:13:23.228Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/f7e914f7d9325abff4057cee62c0fa70263683189f774473cbfb534cd13b/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34cf8167e023ad956c15f36302911d5406bd99a9862c1a8499ea6f7c0e015dc2", size = 9885085, upload-time = "2026-04-24T00:13:25.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/fa69f2221534e80cc5772ac2b7d222011a2acafc2ec7216d5dd174c864ae/matplotlib-3.10.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59476c6d29d612b8e9bb6ce8c5b631be6ba8f9e3a2421f22a02b192c7dd28716", size = 9672358, upload-time = "2026-04-24T00:13:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1a/5a4f747a8b271cbb024946d2dd3c913ab5032ba430626f8c3528ada96b4b/matplotlib-3.10.9-cp314-cp314-win_amd64.whl", hash = "sha256:336b9acc64d309063126edcdaca00db9373af3c476bb94388fe9c5a53ad13e6f", size = 8349970, upload-time = "2026-04-24T00:13:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dc/95d60ecaefe30680a154b52ea96ab4b0dab547f1fd6aa12f5fb655e89cae/matplotlib-3.10.9-cp314-cp314-win_arm64.whl", hash = "sha256:2dc9477819ffd78ad12a20df1d9d6a6bd4fec6aaa9072681465fddca052f1456", size = 8272785, upload-time = "2026-04-24T00:13:34.511Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a0/005d68bc8b8418300ce6591f18586910a8526806e2ab663933d9f20a41e9/matplotlib-3.10.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:da4e09638420548f31c354032a6250e473c68e5a4e96899b4844cf39ddea23fe", size = 8367999, upload-time = "2026-04-24T00:13:36.962Z" },
+    { url = "https://files.pythonhosted.org/packages/22/05/1236cc9290be70b2498af20ca348add76e3fffe7f67b477db5133a84f3ea/matplotlib-3.10.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:345f6f68ecc8da0ca56fad2ea08fde1a115eda530079eca185d50a7bc3e146c6", size = 8264543, upload-time = "2026-04-24T00:13:39.851Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c2/071f5a5ff6c5bd63aaaf2f45c811d9bf2ced94bde188d9e1a519e21d0cba/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4edcfbd8565339aa62f1cd4012f7180926fdbe71850f7b0d3c379c175cd6b66c", size = 9622800, upload-time = "2026-04-24T00:13:42.296Z" },
+    { url = "https://files.pythonhosted.org/packages/95/57/da7d1f10a85624b9e7db68e069dd94e58dc41dbf9463c5921632ecbe3661/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6be157fe17fc37cb95ac1d7374cf717ce9259616edec911a78d9d26dae8522d4", size = 9888561, upload-time = "2026-04-24T00:13:45.026Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/ef8d6bb59b0edb6c16c968b70f548aa13b54348972def5aa6ac85df67145/matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf", size = 9680884, upload-time = "2026-04-24T00:13:48.066Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1c/d21bfeb9931881ebe96bcfcff27c7ae4b160ae0ec291a714c42641a56d75/matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39", size = 8432333, upload-time = "2026-04-24T00:13:51.008Z" },
+    { url = "https://files.pythonhosted.org/packages/78/23/92493c3e6e1b635ccfff146f7b99e674808787915420373ac399283764c2/matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c", size = 8324785, upload-time = "2026-04-24T00:13:53.633Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/f3/257adc69a71011b4c8cda321b00f02c5bf1980ae38ffd05a58d9632d4de8/narwhals-2.20.0.tar.gz", hash = "sha256:c10994975fa7dc5a68c2cffcddbd5908fc8ebb2d463c5bab085309c0ee1f551e", size = 627848, upload-time = "2026-04-20T12:11:45.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/69/f24d3d1c38ad69e256138b4ec2452a8c7cf66be49dc214771ae99dd4f0a0/narwhals-2.20.0-py3-none-any.whl", hash = "sha256:16e750ea5507d4ba6e8d03455b5f93a535e0405976561baea235bca5dc9f475d", size = 449373, upload-time = "2026-04-20T12:11:43.596Z" },
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu12"
+version = "2.30.4"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/2b/1757b6b74ee241de5efee3f35487dcb33e09c07605254809c6ce36aeb783/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:606fa9aa9215c00367d060188eb1a5bbd28396aff5e11b9200d99d1a6ab79a71", size = 300091935, upload-time = "2026-04-23T03:22:58.024Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c3/0e45ff4dce8401f6ea7c25d80d75738813a47f5ae2691e2478f2fd1e5e93/nvidia_nccl_cu12-2.30.4-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:040974b261edec4b8b793e59e92ab7176fe4ab4bc61b800f9f3bfaeec2d436f3", size = 300164158, upload-time = "2026-04-23T03:23:19.589Z" },
+]
+
+[[package]]
+name = "optuna"
+version = "4.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alembic" },
+    { name = "colorlog" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "sqlalchemy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/9b/62f120fb2ecbc4338bee70c5a3671c8e561714f3aa1a046b897ff142050e/optuna-4.8.0.tar.gz", hash = "sha256:6f7043e9f8ecb5e607af86a7eb00fb5ec2be26c3b08c201209a73d36aff37a38", size = 482603, upload-time = "2026-03-16T04:59:58.659Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl", hash = "sha256:c57a7682679c36bfc9bca0da430698179e513874074b71bebedb0334964ab930", size = 419456, upload-time = "2026-03-16T04:59:56.977Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/99/b342345300f13440fe9fe385c3c481e2d9a595ee3bab4d3219247ac94e9a/pandas-3.0.2.tar.gz", hash = "sha256:f4753e73e34c8d83221ba58f232433fca2748be8b18dbca02d242ed153945043", size = 4645855, upload-time = "2026-03-31T06:48:30.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/ca/3e639a1ea6fcd0617ca4e8ca45f62a74de33a56ae6cd552735470b22c8d3/pandas-3.0.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5918ba197c951dec132b0c5929a00c0bf05d5942f590d3c10a807f6e15a57d3", size = 10321105, upload-time = "2026-03-31T06:46:57.327Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/77/dbc82ff2fb0e63c6564356682bf201edff0ba16c98630d21a1fb312a8182/pandas-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d606a041c89c0a474a4702d532ab7e73a14fe35c8d427b972a625c8e46373668", size = 9864088, upload-time = "2026-03-31T06:46:59.935Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2b/341f1b04bbca2e17e13cd3f08c215b70ef2c60c5356ef1e8c6857449edc7/pandas-3.0.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:710246ba0616e86891b58ab95f2495143bb2bc83ab6b06747c74216f583a6ac9", size = 10369066, upload-time = "2026-03-31T06:47:02.792Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c5/cbb1ffefb20a93d3f0e1fdcda699fb84976210d411b008f97f48bf6ce27e/pandas-3.0.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d3cfe227c725b1f3dff4278b43d8c784656a42a9325b63af6b1492a8232209e", size = 10876780, upload-time = "2026-03-31T06:47:06.205Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fe/2249ae5e0a69bd0ddf17353d0a5d26611d70970111f5b3600cdc8be883e7/pandas-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c3b723df9087a9a9a840e263ebd9f88b64a12075d1bf2ea401a5a42f254f084d", size = 11375181, upload-time = "2026-03-31T06:47:09.383Z" },
+    { url = "https://files.pythonhosted.org/packages/de/64/77a38b09e70b6464883b8d7584ab543e748e42c1b5d337a2ee088e0df741/pandas-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3096110bf9eac0070b7208465f2740e2d8a670d5cb6530b5bb884eca495fd39", size = 11928899, upload-time = "2026-03-31T06:47:12.686Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/52/42855bf626868413f761addd574acc6195880ae247a5346477a4361c3acb/pandas-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:07a10f5c36512eead51bc578eb3354ad17578b22c013d89a796ab5eee90cd991", size = 9746574, upload-time = "2026-03-31T06:47:15.64Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/21304ae06a25e8bf9fc820d69b29b2c495b2ae580d1e143146c309941760/pandas-3.0.2-cp313-cp313-win_arm64.whl", hash = "sha256:5fdbfa05931071aba28b408e59226186b01eb5e92bea2ab78b65863ca3228d84", size = 9047156, upload-time = "2026-03-31T06:47:18.595Z" },
+    { url = "https://files.pythonhosted.org/packages/72/20/7defa8b27d4f330a903bb68eea33be07d839c5ea6bdda54174efcec0e1d2/pandas-3.0.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:dbc20dea3b9e27d0e66d74c42b2d0c1bed9c2ffe92adea33633e3bedeb5ac235", size = 10756238, upload-time = "2026-03-31T06:47:22.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/95/49433c14862c636afc0e9b2db83ff16b3ad92959364e52b2955e44c8e94c/pandas-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b75c347eff42497452116ce05ef461822d97ce5b9ff8df6edacb8076092c855d", size = 10408520, upload-time = "2026-03-31T06:47:25.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f8/462ad2b5881d6b8ec8e5f7ed2ea1893faa02290d13870a1600fe72ad8efc/pandas-3.0.2-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1478075142e83a5571782ad007fb201ed074bdeac7ebcc8890c71442e96adf7", size = 10324154, upload-time = "2026-03-31T06:47:28.097Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/65/d1e69b649cbcddda23ad6e4c40ef935340f6f652a006e5cbc3555ac8adb3/pandas-3.0.2-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5880314e69e763d4c8b27937090de570f1fb8d027059a7ada3f7f8e98bdcb677", size = 10714449, upload-time = "2026-03-31T06:47:30.85Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a4/85b59bc65b8190ea3689882db6cdf32a5003c0ccd5a586c30fdcc3ffc4fc/pandas-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b5329e26898896f06035241a626d7c335daa479b9bbc82be7c2742d048e41172", size = 11338475, upload-time = "2026-03-31T06:47:34.026Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c4/bc6966c6e38e5d9478b935272d124d80a589511ed1612a5d21d36f664c68/pandas-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:81526c4afd31971f8b62671442a4b2b51e0aa9acc3819c9f0f12a28b6fcf85f1", size = 11786568, upload-time = "2026-03-31T06:47:36.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/74/09298ca9740beed1d3504e073d67e128aa07e5ca5ca2824b0c674c0b8676/pandas-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:7cadd7e9a44ec13b621aec60f9150e744cfc7a3dd32924a7e2f45edff31823b0", size = 10488652, upload-time = "2026-03-31T06:47:40.612Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/c6ea527147c73b24fc15c891c3fcffe9c019793119c5742b8784a062c7db/pandas-3.0.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:db0dbfd2a6cdf3770aa60464d50333d8f3d9165b2f2671bcc299b72de5a6677b", size = 10326084, upload-time = "2026-03-31T06:47:43.834Z" },
+    { url = "https://files.pythonhosted.org/packages/95/25/bdb9326c3b5455f8d4d3549fce7abcf967259de146fe2cf7a82368141948/pandas-3.0.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0555c5882688a39317179ab4a0ed41d3ebc8812ab14c69364bbee8fb7a3f6288", size = 9914146, upload-time = "2026-03-31T06:47:46.67Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/77/3a227ff3337aa376c60d288e1d61c5d097131d0ac71f954d90a8f369e422/pandas-3.0.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01f31a546acd5574ef77fe199bc90b55527c225c20ccda6601cf6b0fd5ed597c", size = 10444081, upload-time = "2026-03-31T06:47:49.681Z" },
+    { url = "https://files.pythonhosted.org/packages/15/88/3cdd54fa279341afa10acf8d2b503556b1375245dccc9315659f795dd2e9/pandas-3.0.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:deeca1b5a931fdf0c2212c8a659ade6d3b1edc21f0914ce71ef24456ca7a6535", size = 10897535, upload-time = "2026-03-31T06:47:53.033Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9d/98cc7a7624f7932e40f434299260e2917b090a579d75937cb8a57b9d2de3/pandas-3.0.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f48afd9bb13300ffb5a3316973324c787054ba6665cda0da3fbd67f451995db", size = 11446992, upload-time = "2026-03-31T06:47:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/cd/19ff605cc3760e80602e6826ddef2824d8e7050ed80f2e11c4b079741dc3/pandas-3.0.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6c4d8458b97a35717b62469a4ea0e85abd5ed8687277f5ccfc67f8a5126f8c53", size = 11968257, upload-time = "2026-03-31T06:47:59.137Z" },
+    { url = "https://files.pythonhosted.org/packages/db/60/aba6a38de456e7341285102bede27514795c1eaa353bc0e7638b6b785356/pandas-3.0.2-cp314-cp314-win_amd64.whl", hash = "sha256:b35d14bb5d8285d9494fe93815a9e9307c0876e10f1e8e89ac5b88f728ec8dcf", size = 9865893, upload-time = "2026-03-31T06:48:02.038Z" },
+    { url = "https://files.pythonhosted.org/packages/08/71/e5ec979dd2e8a093dacb8864598c0ff59a0cee0bbcdc0bfec16a51684d4f/pandas-3.0.2-cp314-cp314-win_arm64.whl", hash = "sha256:63d141b56ef686f7f0d714cfb8de4e320475b86bf4b620aa0b7da89af8cbdbbb", size = 9188644, upload-time = "2026-03-31T06:48:05.045Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/6c/7b45d85db19cae1eb524f2418ceaa9d85965dcf7b764ed151386b7c540f0/pandas-3.0.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:140f0cffb1fa2524e874dde5b477d9defe10780d8e9e220d259b2c0874c89d9d", size = 10776246, upload-time = "2026-03-31T06:48:07.789Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3e/7b00648b086c106e81766f25322b48aa8dfa95b55e621dbdf2fdd413a117/pandas-3.0.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae37e833ff4fed0ba352f6bdd8b73ba3ab3256a85e54edfd1ab51ae40cca0af8", size = 10424801, upload-time = "2026-03-31T06:48:10.897Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/558dd09a71b53b4008e7fc8a98ec6d447e9bfb63cdaeea10e5eb9b2dabe8/pandas-3.0.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d888a5c678a419a5bb41a2a93818e8ed9fd3172246555c0b37b7cc27027effd", size = 10345643, upload-time = "2026-03-31T06:48:13.7Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e3/921c93b4d9a280409451dc8d07b062b503bbec0531d2627e73a756e99a82/pandas-3.0.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b444dc64c079e84df91baa8bf613d58405645461cabca929d9178f2cd392398d", size = 10743641, upload-time = "2026-03-31T06:48:16.659Z" },
+    { url = "https://files.pythonhosted.org/packages/56/ca/fd17286f24fa3b4d067965d8d5d7e14fe557dd4f979a0b068ac0deaf8228/pandas-3.0.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4544c7a54920de8eeacaa1466a6b7268ecfbc9bc64ab4dbb89c6bbe94d5e0660", size = 11361993, upload-time = "2026-03-31T06:48:19.475Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/76/a1e769043c0c0c9fe391b702539d594731a4362334cdf4dc25d0c09761e7/parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd", size = 401621, upload-time = "2026-02-09T15:45:24.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/61/fae042894f4296ec49e3f193aff5d7c18440da9e48102c3315e1bc4519a7/parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff", size = 106894, upload-time = "2026-02-09T15:45:21.391Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/7f/0f100df1172aadf88a929a9dbb902656b0880ba4b960fe5224867159d8f4/plotly-6.7.0.tar.gz", hash = "sha256:45eea0ff27e2a23ccd62776f77eb43aa1ca03df4192b76036e380bb479b892c6", size = 6911286, upload-time = "2026-04-09T20:36:45.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/ad/cba91b3bcf04073e4d1655a5c1710ef3f457f56f7d1b79dcc3d72f4dd912/plotly-6.7.0-py3-none-any.whl", hash = "sha256:ac8aca1c25c663a59b5b9140a549264a5badde2e057d79b8c772ae2920e32ff0", size = 9898444, upload-time = "2026-04-09T20:36:39.812Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
+    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
+    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/bb/1eb0242409d22db725d7a88088e6cfd6556829fb0736f9ff69aa9f1e9455/xgboost-3.2.0.tar.gz", hash = "sha256:99b0e9a2a64896cdaf509c5e46372d336c692406646d20f2af505003c0c5d70d", size = 1263936, upload-time = "2026-02-10T11:03:05.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/49/6e4cdd877c24adf56cb3586bc96d93d4dcd780b5ea1efb32e1ee0de08bae/xgboost-3.2.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2f661966d3e322536d9c448090a870fcba1e32ee5760c10b7c46bac7a342079a", size = 2507014, upload-time = "2026-02-10T10:50:57.44Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f1/c09ef1add609453aa3ba5bafcd0d1c1a805c1263c0b60138ec968f8ec296/xgboost-3.2.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:eabbd40d474b8dbf6cb3536325f9150b9e6f0db32d18de9914fb3227d0bef5b7", size = 2328527, upload-time = "2026-02-10T10:51:17.502Z" },
+    { url = "https://files.pythonhosted.org/packages/96/9f/d9914a7b8df842832850b1a18e5f47aaa071c217cdd1da2ae9deb291018b/xgboost-3.2.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:852eabc6d3b3702a59bf78dbfdcd1cb9c4d3a3b6e5ed1f8781d8b9512354fdd2", size = 131100954, upload-time = "2026-02-10T11:02:42.704Z" },
+    { url = "https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:99b4a6bbcb47212fec5cf5fbe12347215f073c08967431b0122cfbd1ee70312c", size = 131748579, upload-time = "2026-02-10T10:54:40.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1661dd114a914a67e3f7ab66fa1382e7599c2a8c340f314ad30a3e2b4d08/xgboost-3.2.0-py3-none-win_amd64.whl", hash = "sha256:0d169736fd836fc13646c7ab787167b3a8110351c2c6bc770c755ee1618f0442", size = 101681668, upload-time = "2026-02-10T10:59:31.202Z" },
+]

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,12 @@
+results.tsv
+artifacts/*
+!artifacts/README.md
+history/*
+!history/README.md
+logs/*
+!logs/README.md
+submissions/*
+!submissions/README.md
+__pycache__/
+*.py[cod]
+.ipynb_checkpoints/

--- a/template/AGENTS.md
+++ b/template/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS.md
+
+## Workspace Shape
+- This is a Kaggle competition template inside the shared `/home/cady/personal/kaggle` repo.
+- Competition folders should keep raw data in `data/`, reproducible experiment code in `src/`, optional human notebooks in `notebooks/`, and generated outputs in `artifacts/`, `logs/`, `history/`, or `submissions/`.
+- `README.md` should be replaced with the Kaggle brief for the active competition, and it should include a small benchmark block showing the best current metric.
+- `program.md` describes the autonomous experiment loop.
+- `src/profile_data.py` is the fixed first step for understanding the dataset before experiments start.
+- `src/evaluate.py` is the fixed local harness after the human configures it once; `src/experiment.py` is the agent-owned experimentation surface.
+- `DOCKER.md` and `run_agent_container.sh` provide an optional container wrapper that mounts protected files read-only.
+
+## Environment
+- Use the shared root environment via `uv sync` from the repo root or `uv run ...` from inside the competition folder.
+- The root project requires Python `>=3.13`.
+- Prefer Polars and Matplotlib unless the human explicitly approves a new dependency.
+
+## Working Conventions
+- Treat `data/` as read-only after the competition files land there.
+- Run `src/profile_data.py` and read `artifacts/data_profile.md` before changing `src/experiment.py`.
+- Keep generated experiment logs in `logs/`, plots in `artifacts/`, submissions in `submissions/`, archived run snapshots in `history/`, and the run ledger in `results.tsv`.
+- Run `src/analyze_results.py` after meaningful runs so the benchmark summary and README benchmark block stay fresh.
+- Use `EXPERIMENT_DESCRIPTION` when running the harness so each result row has a readable note.
+- Add short dated notes to `DIARY.md` when a run meaningfully changes the direction of the work.
+- There is no repo-configured test, lint, typecheck, formatter, task runner, or CI workflow. Do not claim those checks ran unless you add the tooling yourself.
+- Prefer script-first automation in `src/`; notebooks are for human exploration, not for the autonomous loop.
+
+## Agent Rules
+- Do not rewrite the human-authored competition narrative in `README.md`; only the benchmark marker block may be refreshed from `results.tsv`.
+- If the human asks for stronger isolation, prefer the container wrapper so `data/`, `src/evaluate.py`, and `src/profile_data.py` stay read-only at the filesystem level.
+- Default autonomous changes to `src/experiment.py`.
+- Use `data/sample_submission.csv` as the source of truth for submission column names and order.
+
+## Git Gotchas
+- `.gitattributes` at the repo root routes `*.csv` and `*.ipynb` through Git LFS. Preserve that when adding or rewriting datasets or notebooks.
+- This template has a local `.gitignore` for `results.tsv`, `artifacts/`, `history/`, `logs/`, and generated submissions. Keep those outputs untracked unless the human asks otherwise.

--- a/template/DIARY.md
+++ b/template/DIARY.md
@@ -1,0 +1,11 @@
+# Diary
+
+Use this file for short human-readable research notes.
+
+Suggested format:
+
+## YYYY-MM-DD
+
+- What changed and why.
+- Result: did the validation metric improve?
+- Follow-up idea or open question.

--- a/template/DOCKER.md
+++ b/template/DOCKER.md
@@ -1,0 +1,46 @@
+# Optional Container Isolation
+
+This template includes an optional Docker runner for cases where you want stronger guardrails around the agent.
+
+The container setup is designed to protect the files that should not move during autonomous experimentation:
+
+- `data/` is mounted read-only.
+- `README.md` is mounted read-only.
+- `program.md` is mounted read-only.
+- `AGENTS.md` is mounted read-only.
+- `src/profile_data.py` is mounted read-only.
+- `src/evaluate.py` is mounted read-only.
+
+The agent can still write where it is supposed to work:
+
+- `src/experiment.py`
+- `artifacts/`
+- `logs/`
+- `submissions/`
+- `history/`
+- `results.tsv`
+- `DIARY.md`
+
+## What The Container Protects
+
+The runner mounts the shared repo root read-only, then overlays the active competition folder as writable, and then overlays the protected files again as read-only.
+
+That means the agent can still use the shared root `pyproject.toml` and `uv.lock`, but it cannot rewrite them from inside the container.
+
+## How To Start The Container
+
+From the competition folder:
+
+```bash
+bash run_agent_container.sh
+```
+
+This opens an interactive shell inside the container after running `uv sync --frozen`.
+
+Inside the container, a project-local `.venv` is created in the competition folder via `UV_PROJECT_ENVIRONMENT=/workspace/competition/.venv` so the shared repo root can remain mounted read-only.
+
+## Notes
+
+- This container setup protects files, not network access.
+- If you later want stricter isolation, the next step is to build a dedicated image and optionally disable network access after the environment is baked.
+- The default workflow can still stay local; use the container when you want extra safety for longer autonomous runs.

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,30 @@
+# <Competition Name>
+
+Replace this file with the Kaggle brief for the competition.
+
+## Current Benchmark
+
+This section is meant to stay short and factual. `src/analyze_results.py` can refresh it from `results.tsv` when `README.md` is writable.
+
+<!-- benchmark:start -->
+- No successful runs logged yet.
+<!-- benchmark:end -->
+
+## Goal
+
+- Predict `<target_column>` from the provided training data.
+
+## Metric
+
+- Optimize `<metric_name>`.
+- Record whether the metric should be maximized or minimized in `src/evaluate.py`.
+
+## Submission
+
+- `data/sample_submission.csv` is the source of truth for submission column names and order.
+
+## Data Files
+
+- `data/train.csv` contains the target column.
+- `data/test.csv` omits the target column.
+- `data/sample_submission.csv` defines the submission schema.

--- a/template/artifacts/README.md
+++ b/template/artifacts/README.md
@@ -1,0 +1,11 @@
+# Artifacts
+
+Generated plots and other derived summaries belong here.
+
+Typical files:
+
+- `data_profile.md`
+- `progress.png`
+- `benchmark_summary.md`
+
+This folder is ignored by the local `.gitignore` except for this README.

--- a/template/data/README.md
+++ b/template/data/README.md
@@ -1,0 +1,11 @@
+# Data Folder
+
+Place Kaggle-provided files here.
+
+Expected files:
+
+- `train.csv`
+- `test.csv`
+- `sample_submission.csv`
+
+Treat this folder as read-only after the competition data lands here.

--- a/template/history/README.md
+++ b/template/history/README.md
@@ -1,0 +1,12 @@
+# History
+
+Each successful harness run can archive a snapshot here.
+
+Recommended contents per run directory:
+
+- `summary.json`
+- the exact `src/experiment.py` that produced the score
+- the submission file, if one was written
+- the latest `artifacts/data_profile.md`, if present
+
+This folder is ignored by the local `.gitignore` except for this README.

--- a/template/logs/README.md
+++ b/template/logs/README.md
@@ -1,0 +1,5 @@
+# Logs
+
+Store baseline and experiment logs here, for example `baseline.log` or `run.log`.
+
+This folder is ignored by the local `.gitignore` except for this README.

--- a/template/notebooks/README.md
+++ b/template/notebooks/README.md
@@ -1,0 +1,5 @@
+# Notebooks
+
+Use this folder for human-facing exploratory notebooks.
+
+Keep autonomous experiment logic in `src/` so diffs stay small and runs stay reproducible.

--- a/template/program.md
+++ b/template/program.md
@@ -1,0 +1,164 @@
+# Kaggle Autoresearch Template
+
+This template adapts the `autoresearch` idea to a Kaggle-style tabular competition.
+
+The human owns the competition brief and the evaluation harness. The agent owns the experiment logic.
+
+## Files In Scope
+
+- `README.md` — Kaggle brief plus a small benchmark block. The benchmark block can be refreshed from `results.tsv` by `src/analyze_results.py`.
+- `src/profile_data.py` — fixed data-understanding script. Run this before any baseline or experiment loop.
+- `src/evaluate.py` — fixed local harness. Human configures the constants once, then freezes it.
+- `src/experiment.py` — the file the agent edits during autonomous experimentation.
+- `results.tsv` — untracked experiment log, auto-appended by the harness.
+- `history/` — archived per-run snapshots, auto-created by the harness.
+- `DIARY.md` — short human-readable research notes.
+- `DOCKER.md` and `run_agent_container.sh` — optional container-based guardrails.
+- `src/analyze_results.py` — optional summary/plotting for `results.tsv`.
+
+## Setup
+
+Before the experiment loop starts:
+
+1. Pick a run tag such as `apr27` or `apr27-gpu0`.
+2. Create a dedicated branch such as `autoresearch/<tag>`.
+3. Read these files for full context:
+   - `README.md`
+   - `AGENTS.md`
+   - `program.md`
+   - `src/profile_data.py`
+   - `src/evaluate.py`
+   - `src/experiment.py`
+4. Verify the competition data exists:
+    - `data/train.csv`
+    - `data/test.csv`
+    - `data/sample_submission.csv`
+   If you want file-system guardrails, start the optional container shell with `bash run_agent_container.sh` before the autonomous loop.
+5. Run the data profile first:
+
+```bash
+uv run src/profile_data.py > logs/profile.log 2>&1
+```
+
+6. Read `artifacts/data_profile.md` and identify the basic modeling constraints before touching `src/experiment.py`.
+7. Confirm the configuration block at the top of `src/evaluate.py` has been updated for this competition.
+8. Run the baseline once. Add a human-readable note with `EXPERIMENT_DESCRIPTION`:
+
+```bash
+EXPERIMENT_DESCRIPTION="baseline" uv run src/evaluate.py > logs/baseline.log 2>&1
+```
+
+9. Read the summary lines from the log:
+
+```bash
+rg "^(run_id|metric_name|metric_direction|metric_value|runtime_seconds|submission_file|experiment|description|snapshot):" logs/baseline.log
+```
+
+10. Confirm that `results.tsv` and `history/<run_id>/summary.json` were created automatically.
+11. Run the analysis refresh so `artifacts/benchmark_summary.md`, `artifacts/progress.png`, and the README benchmark block stay current:
+
+```bash
+uv run src/analyze_results.py
+```
+
+## What The Agent Can Edit
+
+- `src/experiment.py`
+
+## What The Agent Must Not Edit
+
+- `data/`
+- `src/evaluate.py`
+- `src/profile_data.py`
+- `README.md`
+- `program.md`
+- `AGENTS.md`
+- root `pyproject.toml`
+- root `uv.lock`
+
+## Experiment Loop
+
+Repeat until interrupted:
+
+1. Re-read the latest data profile and inspect the current branch and last winning commit.
+2. Make one experiment-sized change in `src/experiment.py`.
+3. Create a commit for that candidate.
+4. Run the harness with a short note describing the idea:
+
+```bash
+EXPERIMENT_DESCRIPTION="your idea here" uv run src/evaluate.py > logs/run.log 2>&1
+```
+
+5. Extract the result summary:
+
+```bash
+rg "^(run_id|metric_name|metric_direction|metric_value|runtime_seconds|submission_file|experiment|description|snapshot):" logs/run.log
+```
+
+6. If the summary is missing, inspect the crash:
+
+```bash
+tail -n 50 logs/run.log
+```
+
+7. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
+8. Update the `status` in `results.tsv` to `keep`, `discard`, or `crash` after you decide what to do with the run.
+9. Run `uv run src/analyze_results.py` to refresh `artifacts/benchmark_summary.md`, `artifacts/progress.png`, and the README benchmark block when writable.
+10. If the metric improved in the configured direction, keep the commit.
+11. If the metric did not improve, restore the prior winning state before trying the next idea.
+
+## Output Contract
+
+`src/evaluate.py` prints a machine-readable block like this:
+
+```text
+---
+run_id:            20260427-101530-a1b2c3d
+metric_name:       balanced_accuracy
+metric_direction:  maximize
+metric_value:      0.587170
+runtime_seconds:   2.4
+submission_file:   submissions/submission-20260427-101530.csv
+experiment:        majority-class baseline
+description:       baseline
+snapshot:          history/20260427-101530-a1b2c3d
+```
+
+## Auto-Recorded Results
+
+The harness auto-appends `results.tsv` using tab-separated values:
+
+```tsv
+run_id	commit	metric_name	metric_direction	metric_value	runtime_seconds	status	description	snapshot
+```
+
+The harness also writes `history/<run_id>/summary.json` and copies the exact `src/experiment.py` used for that run.
+
+## README Benchmark Block
+
+The competition `README.md` should explain the competition and also show the best benchmark seen so far.
+
+Use the marker block in `README.md`:
+
+```md
+<!-- benchmark:start -->
+...
+<!-- benchmark:end -->
+```
+
+`src/analyze_results.py` refreshes that block from `results.tsv` when `README.md` is writable. It always writes `artifacts/benchmark_summary.md` even when the README is read-only.
+
+## Diary
+
+After a significant experiment or decision, add a short dated note to `DIARY.md`.
+
+## Safety Rules
+
+- Treat `data/` as read-only.
+- Do not skip the data-understanding step. Read the profile before proposing model changes.
+- Keep generated artifacts under `artifacts/`, `logs/`, `submissions/`, or `results.tsv`.
+- If you need stronger guardrails, run the loop inside the optional Docker wrapper so protected files are mounted read-only.
+- Review the archived snapshot before deciding to keep or discard a run.
+- Use `data/sample_submission.csv` as the submission schema.
+- Do not create a new submission file unless the run completed successfully.
+- Prefer smaller, reviewable edits over large rewrites.

--- a/template/run_agent_container.sh
+++ b/template/run_agent_container.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+competition_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${competition_dir}/.." && pwd)"
+
+mkdir -p \
+  "${competition_dir}/artifacts" \
+  "${competition_dir}/history" \
+  "${competition_dir}/logs" \
+  "${competition_dir}/submissions"
+
+docker run --rm -it \
+  --workdir /workspace/competition \
+  --mount type=bind,src="${repo_root}",dst=/workspace,readonly \
+  --mount type=bind,src="${competition_dir}",dst=/workspace/competition \
+  --mount type=bind,src="${competition_dir}/AGENTS.md",dst=/workspace/competition/AGENTS.md,readonly \
+  --mount type=bind,src="${competition_dir}/README.md",dst=/workspace/competition/README.md,readonly \
+  --mount type=bind,src="${competition_dir}/program.md",dst=/workspace/competition/program.md,readonly \
+  --mount type=bind,src="${competition_dir}/data",dst=/workspace/competition/data,readonly \
+  --mount type=bind,src="${competition_dir}/src/evaluate.py",dst=/workspace/competition/src/evaluate.py,readonly \
+  --mount type=bind,src="${competition_dir}/src/profile_data.py",dst=/workspace/competition/src/profile_data.py,readonly \
+  --mount type=volume,src=kaggle-agent-uv-cache,dst=/root/.cache/uv \
+  ghcr.io/astral-sh/uv:python3.13-bookworm \
+  bash -lc 'export UV_PROJECT_ENVIRONMENT=/workspace/competition/.venv; uv sync --frozen; exec bash'

--- a/template/src/analyze_results.py
+++ b/template/src/analyze_results.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import datetime, UTC
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import polars as pl
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    results_path = project_root / "results.tsv"
+    artifact_dir = project_root / "artifacts"
+    readme_path = project_root / "README.md"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    if not results_path.exists():
+        raise FileNotFoundError(f"Missing {results_path}. Initialize it before running this report.")
+
+    results = pl.read_csv(results_path, separator="\t")
+    results = results.with_columns(
+        pl.col("status").cast(pl.Utf8).str.to_uppercase(),
+        pl.col("metric_direction").cast(pl.Utf8).str.to_lowercase(),
+        pl.col("metric_value").cast(pl.Float64),
+        pl.col("runtime_seconds").cast(pl.Float64),
+    )
+
+    if results.is_empty():
+        raise ValueError("results.tsv is empty.")
+
+    print(f"Total experiments: {results.height}")
+    print("Experiment outcomes:")
+    print(results.group_by("status").len().sort("status"))
+
+    kept = results.filter(pl.col("status") == "KEEP")
+    decided = results.filter(pl.col("status").is_in(["KEEP", "DISCARD"]))
+    if decided.height:
+        keep_rate = kept.height / decided.height
+        print(f"Keep rate: {kept.height}/{decided.height} = {keep_rate:.1%}")
+
+    metric_name = results.item(0, "metric_name")
+    metric_direction = results.item(0, "metric_direction")
+
+    valid = results.filter(pl.col("status") != "CRASH")
+    if valid.is_empty():
+        raise ValueError("results.tsv contains only crash rows.")
+
+    metric_values = valid["metric_value"].to_list()
+    if metric_direction == "maximize":
+        running_best = cumulative_best(metric_values, max)
+    else:
+        running_best = cumulative_best(metric_values, min)
+
+    best_row = select_best_row(valid, metric_direction)
+
+    kept_x = []
+    kept_y = []
+    kept_labels = []
+    discard_x = []
+    discard_y = []
+
+    for index, row in enumerate(valid.iter_rows(named=True)):
+        if row["status"] == "KEEP":
+            kept_x.append(index)
+            kept_y.append(row["metric_value"])
+            kept_labels.append(row["description"])
+        elif row["status"] == "DISCARD":
+            discard_x.append(index)
+            discard_y.append(row["metric_value"])
+
+    fig, ax = plt.subplots(figsize=(14, 7))
+    if discard_x:
+        ax.scatter(discard_x, discard_y, s=16, c="#cccccc", alpha=0.5, label="Discarded")
+    if kept_x:
+        ax.scatter(kept_x, kept_y, s=42, c="#2ecc71", edgecolors="black", linewidths=0.5, label="Kept")
+        for index, value, label in zip(kept_x, kept_y, kept_labels):
+            short_label = label if len(label) <= 45 else f"{label[:42]}..."
+            ax.annotate(short_label, (index, value), textcoords="offset points", xytext=(6, 6), fontsize=8)
+
+    ax.plot(list(range(len(running_best))), running_best, color="#1f7a3d", linewidth=2, label="Running best")
+    ax.set_title(f"Experiment Progress ({metric_name}, {metric_direction})")
+    ax.set_xlabel("Experiment #")
+    ax.set_ylabel(metric_name)
+    ax.grid(alpha=0.2)
+    ax.legend()
+
+    output_path = artifact_dir / "progress.png"
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+    benchmark_summary = render_benchmark_summary(best_row)
+    summary_path = artifact_dir / "benchmark_summary.md"
+    summary_path.write_text(benchmark_summary, encoding="utf-8")
+
+    readme_updated = update_readme_benchmark_block(readme_path, benchmark_summary)
+
+    print(f"Saved {output_path.relative_to(project_root)}")
+    print(f"Saved {summary_path.relative_to(project_root)}")
+    if readme_updated:
+        print(f"Updated {readme_path.relative_to(project_root)} benchmark block")
+    else:
+        print("Skipped README benchmark update")
+
+
+def cumulative_best(values: list[float], chooser) -> list[float]:
+    best_values: list[float] = []
+    current = values[0]
+    for value in values:
+        current = chooser(current, value)
+        best_values.append(current)
+    return best_values
+
+
+def select_best_row(results: pl.DataFrame, metric_direction: str) -> dict[str, object]:
+    descending = metric_direction == "maximize"
+    return results.sort("metric_value", descending=descending).row(0, named=True)
+
+
+def render_benchmark_summary(best_row: dict[str, object]) -> str:
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    description = str(best_row["description"]).strip() or "-"
+    snapshot = str(best_row["snapshot"]).strip() or "-"
+    return "\n".join(
+        [
+            f"- Metric: `{best_row['metric_name']}` (`{best_row['metric_direction']}`)",
+            f"- Best score: `{float(best_row['metric_value']):.6f}`",
+            f"- Best run: `{best_row['run_id']}`",
+            f"- Status: `{best_row['status']}`",
+            f"- Note: {description}",
+            f"- Snapshot: `{snapshot}`",
+            f"- Last updated: {timestamp}",
+            "",
+        ]
+    )
+
+
+def update_readme_benchmark_block(readme_path: Path, benchmark_summary: str) -> bool:
+    if not readme_path.exists() or not readme_path.is_file():
+        return False
+
+    start_marker = "<!-- benchmark:start -->"
+    end_marker = "<!-- benchmark:end -->"
+    readme_text = readme_path.read_text(encoding="utf-8")
+    if start_marker not in readme_text or end_marker not in readme_text:
+        return False
+
+    start_index = readme_text.index(start_marker) + len(start_marker)
+    end_index = readme_text.index(end_marker)
+    replacement = f"\n{benchmark_summary}"
+    updated_text = readme_text[:start_index] + replacement + readme_text[end_index:]
+    try:
+        readme_path.write_text(updated_text, encoding="utf-8")
+    except OSError:
+        return False
+    return True
+
+
+if __name__ == "__main__":
+    main()

--- a/template/src/evaluate.py
+++ b/template/src/evaluate.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+import math
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import time
+
+import polars as pl
+
+import experiment
+
+
+# Human-owned competition configuration. Update these once per competition,
+# then freeze this file and let the agent iterate only on src/experiment.py.
+TASK_TYPE = "classification"
+TARGET_COLUMN = "<replace-target-column>"
+ID_COLUMN = "id"
+METRIC_NAME = "balanced_accuracy"
+METRIC_DIRECTION = "maximize"
+VALIDATION_FRACTION = 0.2
+WRITE_SUBMISSION = True
+RESULTS_HEADER = (
+    "run_id\tcommit\tmetric_name\tmetric_direction\tmetric_value\t"
+    "runtime_seconds\tstatus\tdescription\tsnapshot\n"
+)
+
+
+@dataclass(frozen=True)
+class CompetitionConfig:
+    task_type: str
+    target_column: str
+    id_column: str
+    metric_name: str
+    metric_direction: str
+    prediction_column: str
+    validation_fraction: float
+    write_submission: bool
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    data_dir = project_root / "data"
+    submission_dir = project_root / "submissions"
+    history_dir = project_root / "history"
+    results_path = project_root / "results.tsv"
+    experiment_note = os.environ.get("EXPERIMENT_DESCRIPTION", "").strip()
+
+    train_path = data_dir / "train.csv"
+    test_path = data_dir / "test.csv"
+    sample_submission_path = data_dir / "sample_submission.csv"
+
+    require_file(train_path)
+    require_file(test_path)
+    require_file(sample_submission_path)
+
+    train_df = pl.read_csv(train_path)
+    test_df = pl.read_csv(test_path)
+    sample_submission = pl.read_csv(sample_submission_path)
+
+    prediction_column = sample_submission.columns[1]
+    config = CompetitionConfig(
+        task_type=TASK_TYPE,
+        target_column=TARGET_COLUMN,
+        id_column=ID_COLUMN,
+        metric_name=METRIC_NAME,
+        metric_direction=METRIC_DIRECTION,
+        prediction_column=prediction_column,
+        validation_fraction=VALIDATION_FRACTION,
+        write_submission=WRITE_SUBMISSION,
+    )
+
+    validate_config(train_df, test_df, sample_submission, config)
+
+    started_at = time.time()
+
+    fit_df, valid_df = split_train_validation(train_df, config)
+    model = experiment.fit_model(fit_df, config)
+    valid_predictions = normalize_predictions(experiment.predict(model, valid_df, config), config, valid_df.height)
+    metric_value = score_predictions(valid_df[config.target_column].to_list(), valid_predictions.to_list(), config)
+
+    submission_file = "-"
+    if config.write_submission:
+        full_model = experiment.fit_model(train_df, config)
+        test_predictions = normalize_predictions(experiment.predict(full_model, test_df, config), config, test_df.height)
+        submission_file = write_submission(test_df, test_predictions, sample_submission, config, submission_dir)
+
+    runtime_seconds = time.time() - started_at
+
+    commit = git_short_commit(project_root)
+    working_tree_dirty = git_is_dirty(project_root)
+    run_id = build_run_id(commit, working_tree_dirty)
+
+    snapshot = archive_run(
+        project_root=project_root,
+        history_dir=history_dir,
+        run_id=run_id,
+        summary={
+            "run_id": run_id,
+            "commit": commit,
+            "working_tree_dirty": working_tree_dirty,
+            "metric_name": config.metric_name,
+            "metric_direction": config.metric_direction,
+            "metric_value": metric_value,
+            "runtime_seconds": runtime_seconds,
+            "experiment": experiment.DESCRIPTION,
+            "description": experiment_note,
+            "submission_file": submission_file,
+        },
+        files_to_copy=[
+            project_root / "src" / "experiment.py",
+            project_root / "artifacts" / "data_profile.md",
+            project_root / submission_file if submission_file != "-" else None,
+        ],
+    )
+
+    append_result(
+        path=results_path,
+        run_id=run_id,
+        commit=commit,
+        metric_name=config.metric_name,
+        metric_direction=config.metric_direction,
+        metric_value=metric_value,
+        runtime_seconds=runtime_seconds,
+        status="ran",
+        description=experiment_note,
+        snapshot=str(snapshot.relative_to(project_root)),
+    )
+
+    print("---")
+    print(f"run_id:            {run_id}")
+    print(f"metric_name:       {config.metric_name}")
+    print(f"metric_direction:  {config.metric_direction}")
+    print(f"metric_value:      {metric_value:.6f}")
+    print(f"runtime_seconds:   {runtime_seconds:.1f}")
+    print(f"submission_file:   {submission_file}")
+    print(f"experiment:        {experiment.DESCRIPTION}")
+    print(f"description:       {experiment_note or '-'}")
+    print(f"snapshot:          {snapshot.relative_to(project_root)}")
+
+
+def require_file(path: Path) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing required file: {path}")
+
+
+def git_short_commit(project_root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "no-git"
+
+    return result.stdout.strip() or "no-git"
+
+
+def git_is_dirty(project_root: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--short"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return False
+
+    return bool(result.stdout.strip())
+
+
+def build_run_id(commit: str, dirty: bool) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    suffix = "dirty" if dirty else commit
+    return f"{timestamp}-{suffix}"
+
+
+def archive_run(
+    project_root: Path,
+    history_dir: Path,
+    run_id: str,
+    summary: dict[str, object],
+    files_to_copy: list[Path | None],
+) -> Path:
+    run_dir = history_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+
+    for file_path in files_to_copy:
+        if file_path is None or not file_path.exists():
+            continue
+        shutil.copy2(file_path, run_dir / file_path.name)
+
+    summary_path = run_dir / "summary.json"
+    summary_with_snapshot = {**summary, "snapshot": str(run_dir.relative_to(project_root))}
+    summary_path.write_text(json.dumps(summary_with_snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return run_dir
+
+
+def append_result(
+    path: Path,
+    run_id: str,
+    commit: str,
+    metric_name: str,
+    metric_direction: str,
+    metric_value: float,
+    runtime_seconds: float,
+    status: str,
+    description: str,
+    snapshot: str,
+) -> None:
+    ensure_results_file(path)
+    row = "\t".join(
+        [
+            run_id,
+            commit,
+            metric_name,
+            metric_direction,
+            f"{metric_value:.6f}",
+            f"{runtime_seconds:.1f}",
+            status,
+            description.replace("\t", " ").strip(),
+            snapshot,
+        ]
+    )
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{row}\n")
+
+
+def ensure_results_file(path: Path) -> None:
+    if not path.exists():
+        path.write_text(RESULTS_HEADER, encoding="utf-8")
+
+
+def validate_config(
+    train_df: pl.DataFrame,
+    test_df: pl.DataFrame,
+    sample_submission: pl.DataFrame,
+    config: CompetitionConfig,
+) -> None:
+    if config.target_column.startswith("<replace-"):
+        raise ValueError("Update TARGET_COLUMN in src/evaluate.py before running the harness.")
+
+    if config.task_type not in {"classification", "regression"}:
+        raise ValueError("TASK_TYPE must be 'classification' or 'regression'.")
+
+    if config.metric_direction not in {"maximize", "minimize"}:
+        raise ValueError("METRIC_DIRECTION must be 'maximize' or 'minimize'.")
+
+    if not 0.0 < config.validation_fraction < 1.0:
+        raise ValueError("VALIDATION_FRACTION must be between 0 and 1.")
+
+    for name, frame in (("train.csv", train_df), ("test.csv", test_df)):
+        if config.id_column not in frame.columns:
+            raise ValueError(f"{config.id_column!r} is missing from {name}.")
+
+    if config.target_column not in train_df.columns:
+        raise ValueError(f"{config.target_column!r} is missing from train.csv.")
+
+    if config.target_column in test_df.columns:
+        raise ValueError(f"{config.target_column!r} should not appear in test.csv.")
+
+    if sample_submission.width != 2:
+        raise ValueError("sample_submission.csv must contain exactly two columns.")
+
+    if sample_submission.columns[0] != config.id_column:
+        raise ValueError(
+            f"sample_submission.csv should start with {config.id_column!r}; "
+            f"found {sample_submission.columns[0]!r}."
+        )
+
+    if not sample_submission[config.id_column].equals(test_df[config.id_column]):
+        raise ValueError("sample_submission.csv ids do not match test.csv ids.")
+
+
+def split_train_validation(train_df: pl.DataFrame, config: CompetitionConfig) -> tuple[pl.DataFrame, pl.DataFrame]:
+    with_buckets = train_df.with_columns(
+        pl.col(config.id_column)
+        .cast(pl.Utf8)
+        .map_elements(stable_bucket, return_dtype=pl.UInt64)
+        .mod(10_000)
+        .alias("_bucket")
+    )
+
+    cutoff = int(config.validation_fraction * 10_000)
+    valid_df = with_buckets.filter(pl.col("_bucket") < cutoff).drop("_bucket")
+    fit_df = with_buckets.filter(pl.col("_bucket") >= cutoff).drop("_bucket")
+
+    if fit_df.is_empty() or valid_df.is_empty():
+        raise ValueError("Validation split produced an empty train or validation set.")
+
+    return fit_df, valid_df
+
+
+def stable_bucket(value: str) -> int:
+    total = 0
+    for char in value:
+        total = (total * 131 + ord(char)) % 1_000_000_007
+    return total
+
+
+def normalize_predictions(predictions: object, config: CompetitionConfig, expected_rows: int) -> pl.Series:
+    if isinstance(predictions, pl.Series):
+        series = predictions.rename(config.prediction_column)
+    else:
+        series = pl.Series(config.prediction_column, predictions)
+
+    if series.len() != expected_rows:
+        raise ValueError(
+            f"Expected {expected_rows} predictions for {config.prediction_column!r}, "
+            f"received {series.len()}."
+        )
+
+    return series
+
+
+def score_predictions(y_true: list[object], y_pred: list[object], config: CompetitionConfig) -> float:
+    if len(y_true) != len(y_pred):
+        raise ValueError("Prediction length does not match ground truth length.")
+
+    metric_name = config.metric_name.lower()
+
+    if metric_name == "accuracy":
+        return sum(actual == predicted for actual, predicted in zip(y_true, y_pred)) / len(y_true)
+
+    if metric_name == "balanced_accuracy":
+        labels = sorted({label for label in y_true})
+        recalls = []
+        for label in labels:
+            positives = sum(actual == label for actual in y_true)
+            true_positives = sum(
+                actual == label and predicted == label
+                for actual, predicted in zip(y_true, y_pred)
+            )
+            recalls.append(true_positives / positives)
+        return sum(recalls) / len(recalls)
+
+    if metric_name == "mae":
+        return sum(abs(float(actual) - float(predicted)) for actual, predicted in zip(y_true, y_pred)) / len(y_true)
+
+    if metric_name == "rmse":
+        squared_error = sum((float(actual) - float(predicted)) ** 2 for actual, predicted in zip(y_true, y_pred))
+        return math.sqrt(squared_error / len(y_true))
+
+    raise ValueError(
+        f"Unsupported METRIC_NAME {config.metric_name!r}. Add it to score_predictions in src/evaluate.py."
+    )
+
+
+def write_submission(
+    test_df: pl.DataFrame,
+    predictions: pl.Series,
+    sample_submission: pl.DataFrame,
+    config: CompetitionConfig,
+    submission_dir: Path,
+) -> str:
+    submission_dir.mkdir(parents=True, exist_ok=True)
+
+    submission = pl.DataFrame(
+        {
+            config.id_column: test_df[config.id_column],
+            config.prediction_column: predictions,
+        }
+    )
+
+    submission = submission.select(sample_submission.columns)
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    output_path = submission_dir / f"submission-{timestamp}.csv"
+    submission.write_csv(output_path)
+    return str(output_path.relative_to(Path(__file__).resolve().parents[1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/template/src/experiment.py
+++ b/template/src/experiment.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections import Counter
+
+import polars as pl
+
+
+DESCRIPTION = "majority-class / train-mean baseline"
+
+
+def fit_model(train_df: pl.DataFrame, config) -> dict[str, object]:
+    target_column = config.target_column
+
+    if config.task_type == "classification":
+        majority_label = Counter(train_df[target_column].to_list()).most_common(1)[0][0]
+        return {"prediction": majority_label}
+
+    mean_value = float(train_df[target_column].mean())
+    return {"prediction": mean_value}
+
+
+def predict(model: dict[str, object], frame: pl.DataFrame, config) -> pl.Series:
+    return pl.Series(config.prediction_column, [model["prediction"]] * frame.height)

--- a/template/src/profile_data.py
+++ b/template/src/profile_data.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+
+
+def main() -> None:
+    project_root = Path(__file__).resolve().parents[1]
+    data_dir = project_root / "data"
+    artifact_dir = project_root / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    train_path = data_dir / "train.csv"
+    test_path = data_dir / "test.csv"
+    sample_submission_path = data_dir / "sample_submission.csv"
+
+    require_file(train_path)
+    require_file(test_path)
+    require_file(sample_submission_path)
+
+    train_df = pl.read_csv(train_path)
+    test_df = pl.read_csv(test_path)
+    sample_submission = pl.read_csv(sample_submission_path)
+
+    id_column = infer_id_column(train_df, test_df, sample_submission)
+    target_column = infer_target_column(train_df, test_df, sample_submission)
+    numeric_features = infer_numeric_features(train_df, target_column, id_column)
+    categorical_features = infer_categorical_features(train_df, target_column)
+
+    report_lines = [
+        "# Data Profile",
+        "",
+        "## Files",
+        "",
+        f"- `train.csv`: {train_df.height} rows x {train_df.width} columns",
+        f"- `test.csv`: {test_df.height} rows x {test_df.width} columns",
+        f"- `sample_submission.csv`: {sample_submission.height} rows x {sample_submission.width} columns",
+        "",
+        "## Inferred Roles",
+        "",
+        f"- id column: `{id_column}`" if id_column else "- id column: could not infer",
+        f"- target column: `{target_column}`" if target_column else "- target column: could not infer",
+        f"- numeric features: {len(numeric_features)}",
+        f"- categorical features: {len(categorical_features)}",
+        "",
+        "## Column Checks",
+        "",
+    ]
+
+    train_only = sorted(set(train_df.columns) - set(test_df.columns))
+    test_only = sorted(set(test_df.columns) - set(train_df.columns))
+    report_lines.append(f"- columns only in train: {format_list(train_only)}")
+    report_lines.append(f"- columns only in test: {format_list(test_only)}")
+    report_lines.append("")
+
+    report_lines.extend(
+        [
+            "## Data Quality",
+            "",
+            f"- duplicate rows in train: {int(train_df.is_duplicated().sum())}",
+            f"- duplicate rows in test: {int(test_df.is_duplicated().sum())}",
+        ]
+    )
+
+    if id_column:
+        report_lines.append(f"- `{id_column}` unique in train: {train_df[id_column].n_unique() == train_df.height}")
+        report_lines.append(f"- `{id_column}` unique in test: {test_df[id_column].n_unique() == test_df.height}")
+        report_lines.append(
+            f"- sample submission ids match test ids: {sample_submission[id_column].equals(test_df[id_column])}"
+        )
+
+    train_nulls = nonzero_null_counts(train_df)
+    test_nulls = nonzero_null_counts(test_df)
+    report_lines.append(f"- null counts in train: {format_counts(train_nulls)}")
+    report_lines.append(f"- null counts in test: {format_counts(test_nulls)}")
+    report_lines.append("")
+
+    if target_column and target_column in train_df.columns:
+        report_lines.extend(target_summary(train_df, target_column))
+
+    if categorical_features:
+        report_lines.extend(categorical_overlap_summary(train_df, test_df, categorical_features))
+
+    if numeric_features:
+        report_lines.extend(numeric_summary(train_df, numeric_features))
+
+    output_path = artifact_dir / "data_profile.md"
+    output_path.write_text("\n".join(report_lines) + "\n", encoding="utf-8")
+    print(f"Wrote {output_path.relative_to(project_root)}")
+
+
+def require_file(path: Path) -> None:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing required file: {path}")
+
+
+def infer_id_column(train_df: pl.DataFrame, test_df: pl.DataFrame, sample_submission: pl.DataFrame) -> str | None:
+    sample_id = sample_submission.columns[0]
+    if sample_id in train_df.columns and sample_id in test_df.columns:
+        return sample_id
+    if "id" in train_df.columns and "id" in test_df.columns:
+        return "id"
+    return None
+
+
+def infer_target_column(train_df: pl.DataFrame, test_df: pl.DataFrame, sample_submission: pl.DataFrame) -> str | None:
+    submission_target = sample_submission.columns[1]
+    if submission_target in train_df.columns and submission_target not in test_df.columns:
+        return submission_target
+
+    train_only = [column for column in train_df.columns if column not in test_df.columns]
+    if len(train_only) == 1:
+        return train_only[0]
+    return None
+
+
+def infer_numeric_features(train_df: pl.DataFrame, target_column: str | None, id_column: str | None) -> list[str]:
+    excluded = {target_column, id_column}
+    return [
+        name
+        for name, dtype in train_df.schema.items()
+        if dtype.is_numeric() and name not in excluded
+    ]
+
+
+def infer_categorical_features(train_df: pl.DataFrame, target_column: str | None) -> list[str]:
+    return [
+        name
+        for name, dtype in train_df.schema.items()
+        if not dtype.is_numeric() and name != target_column
+    ]
+
+
+def nonzero_null_counts(frame: pl.DataFrame) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for column in frame.columns:
+        null_count = int(frame[column].null_count())
+        if null_count:
+            counts[column] = null_count
+    return counts
+
+
+def format_counts(counts: dict[str, int]) -> str:
+    if not counts:
+        return "none"
+    return ", ".join(f"`{column}`={count}" for column, count in counts.items())
+
+
+def format_list(values: list[str]) -> str:
+    if not values:
+        return "-"
+    return ", ".join(f"`{value}`" for value in values)
+
+
+def target_summary(train_df: pl.DataFrame, target_column: str) -> list[str]:
+    lines = ["## Target Summary", ""]
+    target = train_df[target_column]
+
+    if target.dtype.is_numeric() and target.n_unique() > 20:
+        lines.append("- inferred task type: regression-like")
+        lines.append(f"- mean: {float(target.mean()):.6f}")
+        lines.append(f"- median: {float(target.median()):.6f}")
+        lines.append(f"- std: {float(target.std()):.6f}")
+        lines.append(f"- min: {float(target.min()):.6f}")
+        lines.append(f"- max: {float(target.max()):.6f}")
+        lines.append("")
+        return lines
+
+    lines.append("- inferred task type: classification-like")
+    counts = (
+        train_df.group_by(target_column)
+        .len()
+        .rename({"len": "count"})
+        .with_columns((pl.col("count") / pl.col("count").sum()).alias("share"))
+        .sort("count", descending=True)
+    )
+    for row in counts.iter_rows(named=True):
+        lines.append(f"- `{row[target_column]}`: {row['count']} rows ({row['share']:.2%})")
+    lines.append("")
+    return lines
+
+
+def categorical_overlap_summary(
+    train_df: pl.DataFrame,
+    test_df: pl.DataFrame,
+    categorical_features: list[str],
+) -> list[str]:
+    lines = ["## Categorical Overlap", ""]
+    shared_features = [feature for feature in categorical_features if feature in test_df.columns]
+    for feature in shared_features:
+        train_levels = set(train_df[feature].drop_nulls().unique().to_list())
+        test_levels = set(test_df[feature].drop_nulls().unique().to_list())
+        train_only = sorted(train_levels - test_levels)
+        test_only = sorted(test_levels - train_levels)
+        lines.append(
+            f"- `{feature}`: train_only={format_list(train_only)} | test_only={format_list(test_only)}"
+        )
+    lines.append("")
+    return lines
+
+
+def numeric_summary(train_df: pl.DataFrame, numeric_features: list[str]) -> list[str]:
+    lines = ["## Numeric Summary", "", "| feature | mean | std | min | max |", "| --- | ---: | ---: | ---: | ---: |"]
+    for feature in numeric_features:
+        column = train_df[feature]
+        lines.append(
+            f"| `{feature}` | {float(column.mean()):.6f} | {float(column.std()):.6f} | {float(column.min()):.6f} | {float(column.max()):.6f} |"
+        )
+    lines.append("")
+    return lines
+
+
+if __name__ == "__main__":
+    main()

--- a/template/submissions/README.md
+++ b/template/submissions/README.md
@@ -1,0 +1,5 @@
+# Submissions
+
+Write generated Kaggle submission CSV files here.
+
+This folder is ignored by the local `.gitignore` except for this README.


### PR DESCRIPTION
## Summary
- Full competition infrastructure: benchmark split, evaluation harness, analysis pipeline
- CatBoost + LightGBM + XGBoost ensemble experiment runner (best smoke: 0.969515)
- Approach memory with ideas tracking (`artifacts/ideas.md`) for cross-generation agent continuity
- Cached stratified 1%/10% subsets for fast iteration
- Competition template scaffolding for bootstrapping future competitions
- Extended program.md with: 15-min time limit, subset testing strategy, Numba/Polars performance tips

## Benchmark Progress
| Benchmark | Best Score | Approach |
|-----------|-----------|----------|
| smoke | 0.969515 | catboost_v12 (3-model ensemble + threshold opt) |
| full | not run yet | — |

## Dependencies Added (via main)
- optuna, pyarrow, numba