### PR TITLE
fix(irrigation): record crashed runs

### DIFF
--- a/Predicting Irrigation Need/src/evaluate.py
+++ b/Predicting Irrigation Need/src/evaluate.py
@@ -56,51 +56,86 @@ def main() -> None:
     valid_frame = load_benchmark_part(args.benchmark, "valid")
 
     started_at = time.time()
-    validation_predictions = experiment.fit_predict_valid(train_frame, valid_frame, args.benchmark)
-    validate_prediction_contract(validation_predictions)
+    try:
+        validation_predictions = experiment.fit_predict_valid(train_frame, valid_frame, args.benchmark)
+        validate_prediction_contract(validation_predictions)
 
-    experiment_runs_dir = EXPERIMENT_RUNS_DIR
-    experiment_runs_dir.mkdir(parents=True, exist_ok=True)
-    validation_path = experiment_runs_dir / f"{run_id}-{args.benchmark}.csv"
-    validation_predictions.write_csv(validation_path)
+        experiment_runs_dir = EXPERIMENT_RUNS_DIR
+        experiment_runs_dir.mkdir(parents=True, exist_ok=True)
+        validation_path = experiment_runs_dir / f"{run_id}-{args.benchmark}.csv"
+        validation_predictions.write_csv(validation_path)
 
-    metrics = score_prediction_frame(validation_predictions, args.benchmark)
-    metric_value = float(metrics[METRIC_NAME])
+        metrics = score_prediction_frame(validation_predictions, args.benchmark)
+        metric_value = float(metrics[METRIC_NAME])
 
-    submission_file = "-"
-    if args.write_submission:
-        submission_file = write_submission(run_id)
+        submission_file = "-"
+        if args.write_submission:
+            submission_file = write_submission(run_id)
 
-    runtime_seconds = time.time() - started_at
+        runtime_seconds = time.time() - started_at
 
-    summary = {
-        "run_id": run_id,
-        "commit": commit,
-        "working_tree_dirty": working_tree_dirty,
-        "benchmark": args.benchmark,
-        "approach": experiment.APPROACH,
-        "metric_name": METRIC_NAME,
-        "metric_direction": METRIC_DIRECTION,
-        "metric_value": metric_value,
-        "runtime_seconds": runtime_seconds,
-        "metrics": metrics,
-        "experiment": experiment.DESCRIPTION,
-        "description": description,
-        "validation_predictions": str(validation_path.relative_to(PROJECT_ROOT)),
-        "submission_file": submission_file,
-    }
-    snapshot_dir = archive_run(run_id, summary, validation_path, submission_file)
-    append_result(
-        run_id=run_id,
-        commit=commit,
-        benchmark=args.benchmark,
-        approach=experiment.APPROACH,
-        metric_value=metric_value,
-        runtime_seconds=runtime_seconds,
-        status="ran",
-        description=description,
-        snapshot=str(snapshot_dir.relative_to(PROJECT_ROOT)),
-    )
+        summary = {
+            "run_id": run_id,
+            "commit": commit,
+            "working_tree_dirty": working_tree_dirty,
+            "benchmark": args.benchmark,
+            "approach": experiment.APPROACH,
+            "metric_name": METRIC_NAME,
+            "metric_direction": METRIC_DIRECTION,
+            "metric_value": metric_value,
+            "runtime_seconds": runtime_seconds,
+            "metrics": metrics,
+            "experiment": experiment.DESCRIPTION,
+            "description": description,
+            "validation_predictions": str(validation_path.relative_to(PROJECT_ROOT)),
+            "submission_file": submission_file,
+            "status": "ran",
+        }
+        snapshot_dir = archive_run(run_id, summary, validation_path, submission_file)
+        append_result(
+            run_id=run_id,
+            commit=commit,
+            benchmark=args.benchmark,
+            approach=experiment.APPROACH,
+            metric_value=metric_value,
+            runtime_seconds=runtime_seconds,
+            status="ran",
+            description=description,
+            snapshot=str(snapshot_dir.relative_to(PROJECT_ROOT)),
+        )
+    except Exception as exc:
+        runtime_seconds = time.time() - started_at
+        summary = {
+            "run_id": run_id,
+            "commit": commit,
+            "working_tree_dirty": working_tree_dirty,
+            "benchmark": args.benchmark,
+            "approach": experiment.APPROACH,
+            "metric_name": METRIC_NAME,
+            "metric_direction": METRIC_DIRECTION,
+            "metric_value": None,
+            "runtime_seconds": runtime_seconds,
+            "metrics": {},
+            "experiment": experiment.DESCRIPTION,
+            "description": description,
+            "validation_predictions": "-",
+            "submission_file": "-",
+            "status": "crash",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+        snapshot_dir = archive_run(run_id, summary, None, "-")
+        append_result(
+            run_id=run_id,
+            commit=commit,
+            benchmark=args.benchmark,
+            approach=experiment.APPROACH,
+            metric_value=float("nan"),
+            runtime_seconds=runtime_seconds,
+            status="crash",
+            description=description,
+            snapshot=str(snapshot_dir.relative_to(PROJECT_ROOT)),
+        )
+        raise
 
     print("---")
     print(f"run_id:                 {run_id}")
@@ -174,15 +209,16 @@ def build_run_id(commit: str, dirty: bool) -> str:
     return f"{timestamp}-{suffix}"
 
 
-def archive_run(run_id: str, summary: dict[str, object], validation_path: Path, submission_file: str) -> Path:
+def archive_run(run_id: str, summary: dict[str, object], validation_path: Path | None, submission_file: str) -> Path:
     run_dir = HISTORY_DIR / run_id
     run_dir.mkdir(parents=True, exist_ok=False)
 
     files_to_copy = [
         PROJECT_ROOT / "src" / "experiment.py",
-        validation_path,
         PROJECT_ROOT / "artifacts" / "data_profile.md",
     ]
+    if validation_path is not None:
+        files_to_copy.append(validation_path)
     if submission_file != "-":
         files_to_copy.append(PROJECT_ROOT / submission_file)
 

--- a/Predicting Irrigation Need/src/results.py
+++ b/Predicting Irrigation Need/src/results.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+
+import polars as pl
+
+from benchmark import PROJECT_ROOT
+
+RESULTS_PATH = PROJECT_ROOT / "results.tsv"
+VALID_STATUSES = ("ran", "keep", "discard", "crash")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update the experiment results ledger.")
+    parser.add_argument("run_id", help="Run id to update.")
+    parser.add_argument("status", choices=VALID_STATUSES, help="New status value.")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not RESULTS_PATH.exists():
+        raise FileNotFoundError(f"Missing {RESULTS_PATH}")
+
+    results = pl.read_csv(RESULTS_PATH, separator="\t")
+    matches = results.filter(pl.col("run_id") == args.run_id).height
+    if matches == 0:
+        raise ValueError(f"Unknown run_id: {args.run_id}")
+    if matches > 1:
+        raise ValueError(f"Duplicate run_id entries found for: {args.run_id}")
+
+    updated = results.with_columns(
+        pl.when(pl.col("run_id") == args.run_id)
+        .then(pl.lit(args.status))
+        .otherwise(pl.col("status"))
+        .alias("status")
+    )
+    updated.write_csv(RESULTS_PATH, separator="\t")
+    print(f"Updated {args.run_id} to status={args.status}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- record failed benchmark runs in `results.tsv` and `history/` instead of losing them on exceptions
- archive crash summaries with the error message for later review
- add `src/results.py` to update run statuses in the local experiment ledger

## Verification
- `uv run python -m py_compile src/evaluate.py src/results.py`
- `uv run python src/results.py 20260428-010847-dirty ran` (expected to fail cleanly if `results.tsv` is absent in a fresh worktree)