### PR TITLE
docs(irrigation): improve idea handoff

### DIFF
--- a/Predicting Irrigation Need/DIARY.md
+++ b/Predicting Irrigation Need/DIARY.md
@@ -1,11 +1,12 @@
 # Diary
 
-Use this file for short dated research notes.
+Use this file for short dated research notes that help the next agent continue from the current frontier.
 
 Suggested format:
 
 ## YYYY-MM-DD
 
 - What changed and why.
-- Result: did the benchmark improve?
+- Result: did the benchmark improve? Include the run id and score when possible.
+- Decision: keep, discard, or revisit later.
 - Follow-up idea or open question.

--- a/Predicting Irrigation Need/artifacts/ideas.md
+++ b/Predicting Irrigation Need/artifacts/ideas.md
@@ -1,11 +1,16 @@
 # Ideas for Next Experiments
 
-Agents: append your ideas here. Mark them [tried] once tested.
+Agents: append your ideas here before coding. Mark them `[tried]` when execution starts and add a short outcome note after the run.
 
-- Stacking: use CatBoost/LightGBM/XGBoost predictions as features into a logistic regression or ridge meta-learner (instead of simple averaging).
-- Optuna hyperparameter search on the best single model (catboost_v12) — focus on depth, learning_rate, l2_leaf_reg, bagging_temperature.
-- Original dataset: the competition mentions a source dataset. Download it and concatenate with the synthetic train data (with a `is_original` flag feature).
-- More aggressive High-class weighting: current best uses logit/digit thresholds. Try SMOTE oversampling for High class instead.
-- K-fold cross-validation: train with 5-fold CV on `full` benchmark, average predictions. Reduces variance.
-- Feature selection: use SHAP importance from catboost_v12 to drop noisy features and retrain.
-- Neural network: a small tabular MLP (2-3 hidden layers) as an additional ensemble member.
+Suggested entry format:
+
+- `[new]` Idea title | hypothesis: ... | expect: ... | note: pending
+- `[tried]` Idea title | hypothesis: ... | expect: ... | note: improved smoke by ..., crashed because ..., or no signal
+
+- `[new]` Stacking | hypothesis: use CatBoost/LightGBM/XGBoost predictions as features into a logistic regression or ridge meta-learner instead of simple averaging | expect: better calibration and balanced accuracy than naive blending | note: pending
+- `[new]` Optuna on best single CatBoost | hypothesis: the current CatBoost feature set is stronger than the ensemble, so a focused search over depth, learning_rate, l2_leaf_reg, and bagging_temperature may beat the current best | expect: small but real smoke improvement without extra model complexity | note: pending
+- `[new]` Original dataset augmentation | hypothesis: concatenate the source irrigation dataset with the synthetic train data and add an `is_original` flag feature | expect: more robust minority-class signal, especially for `High` | note: pending
+- `[new]` Stronger High-class weighting | hypothesis: the best current setup still under-serves `High`, so more aggressive weighting or oversampling may lift balanced accuracy | expect: recall gain on `High` without collapsing `Low` recall | note: pending
+- `[new]` K-fold CV ensemble | hypothesis: averaging 5 folds on the `full` benchmark will reduce variance versus a single split fit | expect: stabler validation score and possibly stronger submission performance | note: pending
+- `[new]` Feature selection with SHAP | hypothesis: dropping noisy features from the best CatBoost run will simplify the model without losing signal | expect: similar or better score with less runtime and lower overfit risk | note: pending
+- `[new]` Tabular MLP ensemble member | hypothesis: a small neural net may capture interactions the tree models miss | expect: complementary errors that improve an ensemble | note: pending

--- a/Predicting Irrigation Need/program.md
+++ b/Predicting Irrigation Need/program.md
@@ -94,38 +94,42 @@ uv run python src/analyze_results.py
 Repeat until interrupted:
 
 1. Re-read `artifacts/data_profile.md` and `artifacts/approach_memory.md` — compare the best scores there against your new idea to avoid repeating discarded approaches.
-2. Check `artifacts/ideas.md` for untried experiment ideas. Pick one or add your own. Mark it `[tried]` when you start.
-2. Make one experiment-sized change in `src/experiment.py`.
+2. Check `artifacts/ideas.md` for untried experiment ideas. Pick one or add your own.
+3. If you add a new idea, log it in `artifacts/ideas.md` before coding with a short hypothesis and the signal you expect.
+4. Mark the chosen idea `[tried]` when you start, and append a short outcome note after the run so the next agent can build on the result.
+5. Make one experiment-sized change in `src/experiment.py`.
    Update `experiment.APPROACH` and `experiment.DESCRIPTION` so the idea is logged clearly.
-3. Create a commit for that candidate.
-4. Run the harness with a short note:
+6. Create a commit for that candidate.
+7. Run the harness with a short note:
 
 ```bash
 EXPERIMENT_DESCRIPTION="your idea here" uv run python src/evaluate.py --benchmark smoke > logs/run.log 2>&1
 ```
 
-5. Extract the summary:
+8. Extract the summary:
 
 ```bash
 rg "^(run_id|benchmark|metric_name|metric_direction|metric_value|runtime_seconds|validation_predictions|submission_file|experiment|description|snapshot):" logs/run.log
 ```
 
-6. If the summary is missing, inspect the crash:
+9. If the summary is missing, inspect the crash:
 
 ```bash
 tail -n 50 logs/run.log
 ```
 
-7. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
-8. Update the `status` in `results.tsv` to `keep`, `discard`, or `crash` after the decision.
-9. Refresh the analysis outputs, approach memory, and ideas:
+10. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
+11. Update the `status` in `results.tsv` to `keep`, `discard`, or `crash` after the decision.
+
+12. Add a short dated note to `DIARY.md` when the run changes direction, confirms a strong result, or teaches you something reusable.
+13. Refresh the analysis outputs, approach memory, and ideas:
 
 ```bash
 uv run python src/analyze_results.py
 ```
 
-10. If a `smoke` result looks promising, confirm it on `full` before treating it as the new headline benchmark.
-11. Keep the commit only if the benchmark improved enough to justify the complexity.
+14. If a `smoke` result looks promising, confirm it on `full` before treating it as the new headline benchmark.
+15. Keep the commit only if the benchmark improved enough to justify the complexity.
 
 ## Output Contract
 
@@ -166,6 +170,14 @@ It also writes `history/<run_id>/summary.json` and copies the exact `src/experim
 - recent runs with their evaluation outcomes
 
 Read it before the next iteration so the agent can build on prior wins and avoid repeating the same mistake.
+
+## Idea Logging Rules
+
+- `artifacts/ideas.md` is the handoff file for future agents. Add ideas before implementation, not after.
+- Every idea entry should include four things: status, short hypothesis, expected signal, and outcome note.
+- Mark ideas `[tried]` as soon as execution starts, even if the run later crashes.
+- If a run crashes or underperforms, record the failure mode in the idea note so the next agent does not repeat it blindly.
+- If a run works, record what likely caused the gain so the next agent can extend it instead of rediscovering it.
 
 ## README Benchmark Block
 


### PR DESCRIPTION
## Summary
- strengthen `program.md` so agents log hypotheses and outcomes before and after experiments
- turn `artifacts/ideas.md` into a structured handoff file instead of a loose backlog
- expand `DIARY.md` so run ids, decisions, and follow-up questions are carried forward

## Verification
- reviewed the updated workflow text and templates for consistency with the existing experiment loop