### PR TITLE
chore(irrigation): wire workflow helper commands

### DIFF
--- a/Predicting Irrigation Need/program.md
+++ b/Predicting Irrigation Need/program.md
@@ -17,6 +17,9 @@ The key difference from LLM training repos is that the agent must understand the
 - `src/baseline_catboost.py` — reference baseline, not the default experiment surface.
 - `src/leaderboard.py` — ranks prediction CSVs already written under `artifacts/`.
 - `src/analyze_results.py` — refreshes benchmark summaries, progress plots, and approach memory from `results.tsv`.
+- `src/bootstrap.py` — creates the initial data/profile/memory artifacts when they are missing.
+- `src/results.py` — updates the run decision in `results.tsv` after review.
+- `src/notes.py` — updates `artifacts/ideas.md` and `DIARY.md` using the agreed handoff format.
 - `results.tsv` — auto-appended experiment log.
 - `history/` — archived per-run snapshots.
 - `artifacts/approach_memory.md` — generated memory of tried approaches and their outcomes.
@@ -52,20 +55,26 @@ uv run python src/benchmark.py describe
 uv run python src/profile_data.py > logs/profile.log 2>&1
 ```
 
-7. Read `artifacts/data_profile.md`, `artifacts/approach_memory.md`, and `artifacts/ideas.md` before changing `src/experiment.py`.
-8. Run the baseline once on `smoke`:
+7. If the workflow memory files are missing, bootstrap them once:
+
+```bash
+uv run python src/bootstrap.py
+```
+
+8. Read `artifacts/data_profile.md`, `artifacts/approach_memory.md`, and `artifacts/ideas.md` before changing `src/experiment.py`.
+9. Run the baseline once on `smoke`:
 
 ```bash
 EXPERIMENT_DESCRIPTION="baseline" uv run python src/evaluate.py --benchmark smoke > logs/baseline.log 2>&1
 ```
 
-9. Read the summary lines from the log:
+10. Read the summary lines from the log:
 
 ```bash
 rg "^(run_id|benchmark|metric_name|metric_direction|metric_value|runtime_seconds|validation_predictions|submission_file|experiment|description|snapshot):" logs/baseline.log
 ```
 
-10. Refresh the analysis outputs, approach memory, and README benchmark block:
+11. Refresh the analysis outputs, approach memory, and README benchmark block:
 
 ```bash
 uv run python src/analyze_results.py
@@ -95,41 +104,68 @@ Repeat until interrupted:
 
 1. Re-read `artifacts/data_profile.md` and `artifacts/approach_memory.md` — compare the best scores there against your new idea to avoid repeating discarded approaches.
 2. Check `artifacts/ideas.md` for untried experiment ideas. Pick one or add your own.
-3. If you add a new idea, log it in `artifacts/ideas.md` before coding with a short hypothesis and the signal you expect.
-4. Mark the chosen idea `[tried]` when you start, and append a short outcome note after the run so the next agent can build on the result.
-5. Make one experiment-sized change in `src/experiment.py`.
+3. If you add a new idea, log it before coding:
+
+```bash
+uv run python src/notes.py add-idea "idea title" "why this may work" "what signal to expect"
+```
+
+4. Mark the chosen idea `[tried]` when you start:
+
+```bash
+uv run python src/notes.py start-idea "idea title"
+```
+
+5. After the run, append a short outcome note so the next agent can build on the result:
+
+```bash
+uv run python src/notes.py note-idea "idea title" "improved smoke by 0.003, likely from better High recall"
+```
+
+6. Make one experiment-sized change in `src/experiment.py`.
    Update `experiment.APPROACH` and `experiment.DESCRIPTION` so the idea is logged clearly.
-6. Create a commit for that candidate.
-7. Run the harness with a short note:
+7. Create a commit for that candidate.
+8. Run the harness with a short note:
 
 ```bash
 EXPERIMENT_DESCRIPTION="your idea here" uv run python src/evaluate.py --benchmark smoke > logs/run.log 2>&1
 ```
 
-8. Extract the summary:
+9. Extract the summary:
 
 ```bash
 rg "^(run_id|benchmark|metric_name|metric_direction|metric_value|runtime_seconds|validation_predictions|submission_file|experiment|description|snapshot):" logs/run.log
 ```
 
-9. If the summary is missing, inspect the crash:
+10. If the summary is missing, inspect the crash:
 
 ```bash
 tail -n 50 logs/run.log
 ```
 
-10. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
-11. Update the `status` in `results.tsv` to `keep`, `discard`, or `crash` after the decision.
+11. Review the auto-recorded row in `results.tsv` and the archived snapshot in `history/<run_id>/`.
+12. Update the run status after the decision:
 
-12. Add a short dated note to `DIARY.md` when the run changes direction, confirms a strong result, or teaches you something reusable.
-13. Refresh the analysis outputs, approach memory, and ideas:
+```bash
+uv run python src/results.py <run_id> keep
+```
+
+Use `keep`, `discard`, or `crash`.
+
+13. Add a short dated diary note when the run changes direction, confirms a strong result, or teaches you something reusable:
+
+```bash
+uv run python src/notes.py add-diary "what changed and why" "run <run_id> scored ..." "keep" "best follow-up idea"
+```
+
+14. Refresh the analysis outputs, approach memory, and ideas:
 
 ```bash
 uv run python src/analyze_results.py
 ```
 
-14. If a `smoke` result looks promising, confirm it on `full` before treating it as the new headline benchmark.
-15. Keep the commit only if the benchmark improved enough to justify the complexity.
+15. If a `smoke` result looks promising, confirm it on `full` before treating it as the new headline benchmark.
+16. Keep the commit only if the benchmark improved enough to justify the complexity.
 
 ## Output Contract
 
@@ -178,6 +214,7 @@ Read it before the next iteration so the agent can build on prior wins and avoid
 - Mark ideas `[tried]` as soon as execution starts, even if the run later crashes.
 - If a run crashes or underperforms, record the failure mode in the idea note so the next agent does not repeat it blindly.
 - If a run works, record what likely caused the gain so the next agent can extend it instead of rediscovering it.
+- Use `src/notes.py` instead of manually editing `artifacts/ideas.md` or `DIARY.md` when possible so the format stays consistent.
 
 ## README Benchmark Block
 

--- a/Predicting Irrigation Need/src/notes.py
+++ b/Predicting Irrigation Need/src/notes.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+from datetime import date
+
+from benchmark import PROJECT_ROOT
+
+IDEAS_PATH = PROJECT_ROOT / "artifacts" / "ideas.md"
+DIARY_PATH = PROJECT_ROOT / "DIARY.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Update workflow notes for future agents.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_idea = subparsers.add_parser("add-idea", help="Append a new idea entry.")
+    add_idea.add_argument("title")
+    add_idea.add_argument("hypothesis")
+    add_idea.add_argument("expected_signal")
+
+    start_idea = subparsers.add_parser("start-idea", help="Mark an idea as tried.")
+    start_idea.add_argument("title")
+
+    note_idea = subparsers.add_parser("note-idea", help="Append an outcome note to an idea.")
+    note_idea.add_argument("title")
+    note_idea.add_argument("note")
+
+    add_diary = subparsers.add_parser("add-diary", help="Append a dated diary note.")
+    add_diary.add_argument("change")
+    add_diary.add_argument("result")
+    add_diary.add_argument("decision")
+    add_diary.add_argument("follow_up")
+    add_diary.add_argument("--date", dest="entry_date", default=date.today().isoformat())
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.command == "add-idea":
+        add_idea(args.title, args.hypothesis, args.expected_signal)
+        return
+    if args.command == "start-idea":
+        update_idea(args.title, status="tried")
+        return
+    if args.command == "note-idea":
+        update_idea(args.title, note=args.note)
+        return
+    if args.command == "add-diary":
+        add_diary(args.entry_date, args.change, args.result, args.decision, args.follow_up)
+        return
+    raise ValueError(f"Unknown command: {args.command}")
+
+
+def add_idea(title: str, hypothesis: str, expected_signal: str) -> None:
+    ensure_ideas_file()
+    entry = format_idea_entry("new", title, hypothesis, expected_signal, "pending")
+    with IDEAS_PATH.open("a", encoding="utf-8") as handle:
+        if not IDEAS_PATH.read_text(encoding="utf-8").endswith("\n"):
+            handle.write("\n")
+        handle.write(f"{entry}\n")
+    print(f"Added idea: {title}")
+
+
+def update_idea(title: str, status: str | None = None, note: str | None = None) -> None:
+    ensure_ideas_file()
+    lines = IDEAS_PATH.read_text(encoding="utf-8").splitlines()
+    updated_lines: list[str] = []
+    matched = False
+
+    for line in lines:
+        if is_idea_line_for_title(line, title) and not matched:
+            matched = True
+            updated_lines.append(rewrite_idea_line(line, status=status, note=note))
+        else:
+            updated_lines.append(line)
+
+    if not matched:
+        raise ValueError(f"Idea not found: {title}")
+
+    IDEAS_PATH.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
+    print(f"Updated idea: {title}")
+
+
+def add_diary(entry_date: str, change: str, result: str, decision: str, follow_up: str) -> None:
+    ensure_diary_file()
+    content = DIARY_PATH.read_text(encoding="utf-8")
+    lines: list[str] = []
+    if content and not content.endswith("\n"):
+        content += "\n"
+    if content.strip():
+        lines.append(content.rstrip("\n"))
+    lines.extend(
+        [
+            f"## {entry_date}",
+            "",
+            f"- What changed and why: {change}",
+            f"- Result: {result}",
+            f"- Decision: {decision}",
+            f"- Follow-up idea or open question: {follow_up}",
+        ]
+    )
+    DIARY_PATH.write_text("\n\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Added diary entry for {entry_date}")
+
+
+def ensure_ideas_file() -> None:
+    if IDEAS_PATH.exists():
+        return
+    IDEAS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    IDEAS_PATH.write_text(
+        "# Ideas for Next Experiments\n\n"
+        "Agents: append your ideas here before coding. Mark them `[tried]` when execution starts and add a short outcome note after the run.\n\n"
+        "Suggested entry format:\n\n"
+        "- `[new]` Idea title | hypothesis: ... | expect: ... | note: pending\n"
+        "- `[tried]` Idea title | hypothesis: ... | expect: ... | note: improved smoke by ..., crashed because ..., or no signal\n",
+        encoding="utf-8",
+    )
+
+
+def ensure_diary_file() -> None:
+    if DIARY_PATH.exists():
+        return
+    DIARY_PATH.write_text(
+        "# Diary\n\n"
+        "Use this file for short dated research notes that help the next agent continue from the current frontier.\n\n"
+        "Suggested format:\n\n"
+        "## YYYY-MM-DD\n\n"
+        "- What changed and why.\n"
+        "- Result: did the benchmark improve? Include the run id and score when possible.\n"
+        "- Decision: keep, discard, or revisit later.\n"
+        "- Follow-up idea or open question.\n",
+        encoding="utf-8",
+    )
+
+
+def format_idea_entry(status: str, title: str, hypothesis: str, expected_signal: str, note: str) -> str:
+    return f"- `[{status}]` {title} | hypothesis: {hypothesis} | expect: {expected_signal} | note: {note}"
+
+
+def is_idea_line_for_title(line: str, title: str) -> bool:
+    return line.startswith("- `[") and f"]` {title} |" in line
+
+
+def rewrite_idea_line(line: str, status: str | None = None, note: str | None = None) -> str:
+    parts = line.split(" | ")
+    head = parts[0]
+    if status is not None:
+        marker_start = head.find("`[")
+        marker_end = head.find("]`", marker_start)
+        if marker_start == -1 or marker_end == -1:
+            raise ValueError(f"Idea line has unexpected format: {line}")
+        head = f"{head[:marker_start]}`[{status}]`{head[marker_end + 2:]}"
+    if note is not None:
+        replaced = False
+        for index, part in enumerate(parts):
+            if part.startswith("note: "):
+                parts[index] = f"note: {note}"
+                replaced = True
+                break
+        if not replaced:
+            parts.append(f"note: {note}")
+        parts[0] = head
+        return " | ".join(parts)
+    parts[0] = head
+    return " | ".join(parts)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `src/notes.py` so agents can add ideas, mark them tried, append outcome notes, and write dated diary entries with a consistent format
- update `program.md` to use `src/bootstrap.py`, `src/results.py`, and `src/notes.py` instead of relying on manual file edits
- keep the change scoped to workflow plumbing so it does not touch the active modeling surface

## Verification
- `uv run python -m py_compile src/notes.py src/bootstrap.py src/results.py`
- exercised `src/notes.py` end-to-end in the clean worktree, then restored the temporary smoke-note edits before commit